### PR TITLE
Minor updates spring2022

### DIFF
--- a/app/controllers/author/committee_members_controller.rb
+++ b/app/controllers/author/committee_members_controller.rb
@@ -57,7 +57,7 @@ class Author::CommitteeMembersController < AuthorController
   end
 
   def show
-    status_giver.can_create_or_edit_committee?
+    status_giver.can_review_committee?
   rescue SubmissionStatusGiver::AccessForbidden
     flash[:alert] = 'You have not completed the required steps to review your committee yet'
     redirect_to author_root_path

--- a/app/models/submission_status_giver.rb
+++ b/app/models/submission_status_giver.rb
@@ -59,24 +59,12 @@ class SubmissionStatusGiver
     validate_current_state! [SubmissionStates::CollectingCommittee,
                              SubmissionStates::CollectingFormatReviewFiles,
                              SubmissionStates::CollectingFormatReviewFilesRejected,
-                             SubmissionStates::WaitingForFormatReviewResponse,
                              SubmissionStates::CollectingFinalSubmissionFiles,
-                             SubmissionStates::CollectingFinalSubmissionFilesRejected,
-                             SubmissionStates::FormatReviewAccepted,
-                             SubmissionStates::WaitingForCommitteeReview,
-                             SubmissionStates::WaitingForHeadOfProgramReview,
-                             SubmissionStates::WaitingForCommitteeReviewRejected,
-                             SubmissionStates::WaitingForFinalSubmissionResponse,
-                             SubmissionStates::WaitingForPublicationRelease,
-                             SubmissionStates::ReleasedForPublication,
-                             SubmissionStates::CollectingFormatReviewFilesRejected,
                              SubmissionStates::CollectingFinalSubmissionFilesRejected]
   end
 
   def can_review_committee?
     validate_current_state! [SubmissionStates::WaitingForFormatReviewResponse,
-                             SubmissionStates::CollectingFinalSubmissionFiles,
-                             SubmissionStates::CollectingFinalSubmissionFilesRejected,
                              SubmissionStates::FormatReviewAccepted,
                              SubmissionStates::WaitingForFinalSubmissionResponse,
                              SubmissionStates::WaitingForPublicationRelease,
@@ -84,7 +72,10 @@ class SubmissionStatusGiver
                              SubmissionStates::ReleasedForPublication,
                              SubmissionStates::CollectingFormatReviewFilesRejected,
                              SubmissionStates::CollectingFinalSubmissionFilesRejected,
-                             SubmissionStates::WaitingForAdvisorReview]
+                             SubmissionStates::WaitingForAdvisorReview,
+                             SubmissionStates::WaitingForCommitteeReview,
+                             SubmissionStates::WaitingForHeadOfProgramReview,
+                             SubmissionStates::WaitingForCommitteeReviewRejected]
   end
 
   def can_review_format_review_files?

--- a/app/views/admin/reports/_submissions.json.jbuilder
+++ b/app/views/admin/reports/_submissions.json.jbuilder
@@ -7,5 +7,6 @@ json.array! [
   submission.program ? submission.program.name : nil,
   submission.current_access_level.label,
   submission.status.titleize,
-  CommitteeMember.advisor_name(submission)
+  CommitteeMember.advisor_name(submission),
+  submission.admin_notes&.truncate(30)
 ]

--- a/app/views/admin/reports/custom_report_index.html.erb
+++ b/app/views/admin/reports/custom_report_index.html.erb
@@ -49,6 +49,7 @@
       <th data-name="access_level" data-orderable="true">Access Level</th>
       <th data-name="submission_status" data-orderable="true">Status</th>
       <th data-name="advisor_name" data-orderable="true">Advisor Name</th>
+      <th data-name="notes" data-orderable="false">Notes</th>
   </tr>
  </thead>
 

--- a/app/views/admin/submissions/print/_signatory_page_bottom.html.erb
+++ b/app/views/admin/submissions/print/_signatory_page_bottom.html.erb
@@ -14,18 +14,6 @@
   </ul>
   <ul>
     <li class='col-left'><span class='print-label'>REVIEW DATE</span><span class='empty-underline'></span></li>
-    <li class='col-right'><span class='print-label'>PROQUEST FORM</span><span class='empty-underline'></span></li>
-  </ul>
-  <ul>
-    <li class='col-left'>&nbsp;</li>
-    <li class='col-right'><span class='print-label'>SED FORM</span><span class='empty-underline'></span></li>
-  </ul>
-  <ul>
-    <li class='col-left'><span class='print-label'>INTENT</span><span class='empty-underline'></span></li>
-    <li class='col-right'><span class='print-label'>__# OF SIGNATURES</span><span class='empty-underline'></span></li>
-  </ul>
-  <ul>
-    <li class='col-left'>&nbsp;</li>
     <li class='col-right'><span class='print-label'>EXCEL</span><span class='empty-underline'></span></li>
   </ul>
   <ul>
@@ -33,7 +21,7 @@
     <li class='col-right'><span class='print-label'>LIONPATH</span><span class='empty-underline'></span></li>
   </ul>
   <ul>
-    <li class='col-left'>&nbsp;</li>
+    <li class='col-left'><span class='print-label'>INTENT</span><span class='empty-underline'></span></li>
     <li class='col-right'><span class='print-label'>OTD APPROVAL DATE</span><span class='empty-underline'></span></li>
   </ul>
   <ul>

--- a/app/views/author/submissions/edit_final_submission.html.erb
+++ b/app/views/author/submissions/edit_final_submission.html.erb
@@ -10,6 +10,18 @@
 <%= render partial: 'confirm_dialog' %>
 <%= render partial: 'fees_confirm_dialog' %>
 
+<% if current_partner.graduate? %>
+  <br />
+  <div class="alert alert-info">
+    <strong class="hint">
+      <span class="text-info">
+        <strong>Notice:</strong>
+      </span> All committee members must review your <%= @submission.degree_type.to_s.downcase %> before uploading your
+      final submission. Any changes should be made before uploading as well.  Changes cannot be made after submission.
+    </strong>
+  </div>
+<% end %>
+
 <%= simple_form_for [:author, @submission], url: author_submission_update_final_submission_path do |f| %>
       <% if @submission.final_submission_notes.present? %>
         <div id="final-submission-notes" class="col-sm-12">

--- a/app/views/author/submissions/index.html.erb
+++ b/app/views/author/submissions/index.html.erb
@@ -3,6 +3,9 @@
   <div class="col-xs-12">
     <br/>
     <p class="thesis_info">You will need to input your committee, upload your format review document, and upload your final document to be published. The site administrator will check the format review document for compliance to standards, and send an email detailing any format changes required.  Once the status of your format review is updated to "Approved", a final document may be submitted.  Your committee will then give a final approval.  </p>
+    <% if current_partner.graduate? %>
+      <p class="thesis_info">There is a <strong>one-time</strong> fee for each thesis and/or dissertation submission required prior to the final submission of the thesis or dissertation.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>.  You will not be permitted to submit your final document unless the fee is paid.</p>
+    <% end %>
   </div>
 </div>
 <!-- TODO: Remove the following info in a year */ -->

--- a/app/views/workflow_mailer/format_review_received.text.erb
+++ b/app/views/workflow_mailer/format_review_received.text.erb
@@ -1,4 +1,5 @@
 Dear <%= @author.full_name %>,
 
-<%= t( "#{current_partner.id}.partner.email.format_review_received.message", degree_type: @submission.degree_type) %>
+<%= t( "#{current_partner.id}.partner.email.format_review_received.message",
+       degree_type: @submission.degree_type) %>
 

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -64,6 +64,9 @@ en:
                     you when the review has been completed.
                     You will receive the results of the review by email within 2-3 weeks.
 
+                    If you have not already done so, you must pay your thesis fee here: https://secure.gradsch.psu.edu/paymentportal/
+                    You only need to pay once.
+
                     Please be aware that the order of the approval process for the final %{degree_type} has been revised.
                     The committee members will now approve the %{degree_type} prior to the Office of Theses and Dissertations.
                     The review and approval of the final submission by each committee member should be completed

--- a/spec/integration/admin/reports/reports_spec.rb
+++ b/spec/integration/admin/reports/reports_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "Admins can run reports", js: true do
                       semester: submission_semester,
                       title: 'Submission1',
                       degree_id: degree1.id,
-                      access_level: 'open_access'
+                      access_level: 'open_access',
+                      admin_notes: 'Some Admin Notes'
   end
   let!(:submission2) do
     FactoryBot.create :submission,
@@ -130,6 +131,7 @@ RSpec.describe "Admins can run reports", js: true do
       expect(page).to have_content(author2.last_name)
       expect(page).not_to have_content(author3.last_name)
       expect(page).to have_content(submission2.program.name)
+      expect(page).to have_content(submission1.admin_notes)
       expect(page).not_to have_content(submission3.program.name) if current_partner.graduate?
       click_button 'Select Visible'
       page.assert_selector('tbody .row-checkbox')

--- a/spec/integration/author/committee/standard_committee_members_spec.rb
+++ b/spec/integration/author/committee/standard_committee_members_spec.rb
@@ -65,18 +65,19 @@ RSpec.describe 'The standard committee form for authors', js: true do
         expect(submission.committee_members.count).to eq(submission.required_committee_roles.count)
         expect(submission.committee_members.first.access_id).to eq('pbm123') unless current_partner.graduate?
         expect(submission.committee_members.second.access_id).to eq('pbm123') if current_partner.graduate?
-        visit author_submission_committee_members_path(submission)
+        visit edit_author_submission_committee_members_path(submission)
         submission.required_committee_roles.count.times do |i|
+          emails = find_all('input.email')
           if i == 0 && current_partner.graduate?
             expect(page).to have_content(program_chair.first_name + ' ' + program_chair.last_name)
-            expect(page).to have_content(program_chair.email)
+            expect(emails[i].value).to eq(program_chair.email)
             next
           end
           # expect(page).to have_content role.name
           name = "Professor Buck Murphy #{i}"
           email = "buck@hotmail.com"
-          expect(page).to have_content(name)
-          expect(page).to have_content(email)
+          expect(find("#submission_committee_members_attributes_#{i}_name").value).to eq(name)
+          expect(emails[i].value).to eq(email)
         end
       end
     end

--- a/spec/integration/author/status_giver/collecting_committee_spec.rb
+++ b/spec/integration/author/status_giver/collecting_committee_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Step 2: Collecting Committee status', js: true do
     context "visiting the 'Review Committee' page" do
       it "raises a forbidden access error" do
         visit author_submission_committee_members_path(submission)
-        expect(page).to have_current_path(author_submission_committee_members_path(submission))
+        expect(page).to have_current_path(author_root_path)
       end
     end
 

--- a/spec/integration/author/status_giver/collecting_final_submission_files_spec.rb
+++ b/spec/integration/author/status_giver/collecting_final_submission_files_spec.rb
@@ -49,10 +49,9 @@ RSpec.describe 'Step 5: Collecting Final Submission Files', js: true do
     end
 
     context "visiting the 'Review Committee' page" do
-      it 'displays the committee information page' do
+      it 'raises a forbidden access error' do
         visit author_submission_committee_members_path(submission)
-        expect(page).to have_content(submission.committee_members.first.name)
-        expect(page).to have_current_path(author_submission_committee_members_path(submission))
+        expect(page).to have_current_path(author_root_path)
       end
     end
 

--- a/spec/integration/author/status_giver/collecting_format_review_files_spec.rb
+++ b/spec/integration/author/status_giver/collecting_format_review_files_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Step 3: Collecting Format Review Files', js: true do
     context "visiting the 'Review Committee' page" do
       it "raises a forbidden access error" do
         visit author_submission_committee_members_path(submission)
-        expect(page).to have_current_path(author_submission_committee_members_path(submission))
+        expect(page).to have_current_path(author_root_path)
       end
     end
 

--- a/spec/integration/author/status_giver/waiting_for_format_review_response_spec.rb
+++ b/spec/integration/author/status_giver/waiting_for_format_review_response_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Step 4: Waiting for Format Review Response', js: true do
     end
 
     context "visiting the 'Review Committee' page" do
-      it "raises a forbidden access error" do
+      it "displays committee member show page" do
         visit author_submission_committee_members_path(submission)
         expect(page).to have_current_path(author_submission_committee_members_path(submission))
       end

--- a/spec/models/submission_status_giver_spec.rb
+++ b/spec/models/submission_status_giver_spec.rb
@@ -1229,7 +1229,7 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1238,16 +1238,16 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting for format review response'" do
       before { submission.status = 'waiting for format review response' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1256,7 +1256,7 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1272,36 +1272,36 @@ RSpec.describe SubmissionStatusGiver, type: :model do
     context "when status is 'waiting for committee review'" do
       before { submission.status = 'waiting for committee review' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting for head of program review'" do
       before { submission.status = 'waiting for head of program review' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting for final submission response'" do
       before { submission.status = 'waiting for final submission response' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting for publication release'" do
       before { submission.status = 'waiting for publication release' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1317,9 +1317,9 @@ RSpec.describe SubmissionStatusGiver, type: :model do
     context "when status is 'released for publication'" do
       before { submission.status = 'released for publication' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_create_or_edit_committee? }.not_to raise_error
+        expect { giver.can_create_or_edit_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
   end
@@ -1364,9 +1364,9 @@ RSpec.describe SubmissionStatusGiver, type: :model do
     context "when status is 'collecting final submission files'" do
       before { submission.status = 'collecting final submission files' }
 
-      it "does not raise an exception" do
+      it "raises an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.not_to raise_error
+        expect { giver.can_review_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1382,18 +1382,18 @@ RSpec.describe SubmissionStatusGiver, type: :model do
     context "when status is 'waiting for committee review'" do
       before { submission.status = 'waiting for committee review' }
 
-      it "raises an exception" do
+      it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting for head of program review'" do
       before { submission.status = 'waiting for head of program review' }
 
-      it "raises an exception" do
+      it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.to raise_error(SubmissionStatusGiver::AccessForbidden)
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1402,7 +1402,7 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.not_to raise_error
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1411,16 +1411,16 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.not_to raise_error
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
     context "when status is 'waiting in final submission on hold'" do
       before { submission.status = 'waiting in final submission on hold' }
 
-      it "raises an exception" do
+      it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.not_to raise_error
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
 
@@ -1429,7 +1429,7 @@ RSpec.describe SubmissionStatusGiver, type: :model do
 
       it "does not raise an exception" do
         giver = described_class.new(submission)
-        expect { giver.can_review_committee? }.not_to raise_error
+        expect { giver.can_review_committee? }.not_to raise_error(SubmissionStatusGiver::AccessForbidden)
       end
     end
   end


### PR DESCRIPTION
Minor wording and additions for Spring 2022:

- Help text and email wording indicating there is a thesis fee
- Added 'Notes' to custom report
- Removed some unneeded fields for submission form
- Fixed bug where authors could not review committee when at advisor stage