### PR TITLE
Hotfix:  Using degree.name when sending code to gradsch webservice in…

### DIFF
--- a/app/services/fee_payment_service.rb
+++ b/app/services/fee_payment_service.rb
@@ -32,19 +32,15 @@ class FeePaymentService
     end
 
     def query
-      "?psuid=#{author_psu_idn}&degree=#{degree_type_code}"
+      "?psuid=#{author_psu_idn}&degree=#{degree_name}"
     end
 
     def author_psu_idn
       submission.author.psu_idn
     end
 
-    def degree_type_code
-      if submission.degree_type.name == "Dissertation"
-        "PHD"
-      else
-        "MS"
-      end
+    def degree_name
+      submission.degree.name
     end
 
     attr_accessor :submission

--- a/spec/services/fee_payment_service_spec.rb
+++ b/spec/services/fee_payment_service_spec.rb
@@ -4,10 +4,15 @@ require 'shoulda-matchers'
 RSpec.describe FeePaymentService do
   let(:service) { described_class.new(submission) }
   let!(:submission) { create :submission }
+  before do
+    submission.degree.name = 'PHD'
+    submission.save!
+  end
 
   context "when the student's fee has been paid" do
-    context "when the submission degree_type is Dissertation" do
+    context "when the submission degree is PHD" do
       it 'returns true' do
+
         stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=PHD&psuid=#{submission.author.psu_idn}")
           .with(
             headers: {
@@ -21,9 +26,9 @@ RSpec.describe FeePaymentService do
       end
     end
 
-    context "when the submission degree_type is Master Thesis" do
+    context "when the submission degree is MS" do
       it 'returns true' do
-        submission.degree.degree_type = DegreeType.find_by(name: 'Master Thesis')
+        submission.degree.name = 'MS'
         submission.save!
         stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=MS&psuid=#{submission.author.psu_idn}")
           .with(
@@ -34,6 +39,23 @@ RSpec.describe FeePaymentService do
             }
           )
           .to_return(status: 200, body: "\r\n    {\"data\":[{\"ETDPAYMENTFOUND\":\"Y\"}],\"error\":\"\"}\r\n    ", headers: {})
+        expect(service.fee_is_paid?).to eq true
+      end
+    end
+
+    context "when the submission degree is DED" do
+      it 'returns true' do
+        submission.degree.name = 'DED'
+        submission.save!
+        stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=DED&psuid=#{submission.author.psu_idn}")
+            .with(
+                headers: {
+                    'Accept' => '*/*',
+                    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                    'User-Agent' => 'Ruby'
+                }
+            )
+            .to_return(status: 200, body: "\r\n    {\"data\":[{\"ETDPAYMENTFOUND\":\"Y\"}],\"error\":\"\"}\r\n    ", headers: {})
         expect(service.fee_is_paid?).to eq true
       end
     end

--- a/spec/services/fee_payment_service_spec.rb
+++ b/spec/services/fee_payment_service_spec.rb
@@ -4,6 +4,7 @@ require 'shoulda-matchers'
 RSpec.describe FeePaymentService do
   let(:service) { described_class.new(submission) }
   let!(:submission) { create :submission }
+
   before do
     submission.degree.name = 'PHD'
     submission.save!
@@ -12,7 +13,6 @@ RSpec.describe FeePaymentService do
   context "when the student's fee has been paid" do
     context "when the submission degree is PHD" do
       it 'returns true' do
-
         stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=PHD&psuid=#{submission.author.psu_idn}")
           .with(
             headers: {
@@ -48,14 +48,14 @@ RSpec.describe FeePaymentService do
         submission.degree.name = 'DED'
         submission.save!
         stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=DED&psuid=#{submission.author.psu_idn}")
-            .with(
-                headers: {
-                    'Accept' => '*/*',
-                    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-                    'User-Agent' => 'Ruby'
-                }
-            )
-            .to_return(status: 200, body: "\r\n    {\"data\":[{\"ETDPAYMENTFOUND\":\"Y\"}],\"error\":\"\"}\r\n    ", headers: {})
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: "\r\n    {\"data\":[{\"ETDPAYMENTFOUND\":\"Y\"}],\"error\":\"\"}\r\n    ", headers: {})
         expect(service.fee_is_paid?).to eq true
       end
     end


### PR DESCRIPTION
…stead of degree_type.name.  We need to pick up things like DED, MA, etc.