### PR TITLE
Fixes ConfidentialHoldUpdateService

### DIFF
--- a/app/controllers/author_controller.rb
+++ b/app/controllers/author_controller.rb
@@ -28,7 +28,6 @@ class AuthorController < ApplicationController
     end
 
     def update_confidential_hold
-      update_service = ConfidentialHoldUpdateService.new(@author, 'login_controller')
-      update_service.update
+      ConfidentialHoldUpdateService.update(@author)
     end
 end

--- a/app/models/ldap_university_directory.rb
+++ b/app/models/ldap_university_directory.rb
@@ -83,6 +83,18 @@ class LdapUniversityDirectory
     false
   end
 
+  def with_connection
+    Net::LDAP.open(host: ldap_configuration['host'],
+                   port: ldap_configuration['port'],
+                   encryption: { method: :simple_tls },
+                   auth: { method: :simple, username: "uid=#{ldap_configuration['user']},dc=psu,dc=edu",
+                           password: ldap_configuration['password'] }) do |connection|
+      yield connection
+    end
+  rescue Net::LDAP::Error
+    raise UnreachableError
+  end
+
   private
 
     def get_ldap_attribute(this_access_id, this_attribute)
@@ -105,18 +117,6 @@ class LdapUniversityDirectory
         raise ResultError, conn.get_operation_result.message if attrs.nil?
       end
       attrs
-    end
-
-    def with_connection
-      Net::LDAP.open(host: ldap_configuration['host'],
-                     port: ldap_configuration['port'],
-                     encryption: { method: :simple_tls },
-                     auth: { method: :simple, username: "uid=#{ldap_configuration['user']},dc=psu,dc=edu",
-                             password: ldap_configuration['password'] }) do |connection|
-        yield connection
-      end
-    rescue Net::LDAP::Error
-      raise UnreachableError
     end
 
     def string_has_wildcard_character?(term)

--- a/app/models/mock_university_directory.rb
+++ b/app/models/mock_university_directory.rb
@@ -135,4 +135,8 @@ class MockUniversityDirectory
         administrator: true, site_administrator: true }
     end
   end
+
+  def with_connection
+    yield
+  end
 end

--- a/app/services/confidential_hold_update_service.rb
+++ b/app/services/confidential_hold_update_service.rb
@@ -22,7 +22,7 @@ class ConfidentialHoldUpdateService
 
       def ldap_result_connected(author, connection)
         attrs = []
-        attrs = connection.search(base: base,
+        attrs = connection.search(base: ldap_base,
                                   filter: Net::LDAP::Filter.eq('uid', author.access_id), attributes: attrs)
         mapped_attributes = LdapResult.new(ldap_record: attrs,
                                            attribute_map: LdapResultsMap::AUTHOR_LDAP_MAP).map_directory_info

--- a/app/services/confidential_hold_update_service.rb
+++ b/app/services/confidential_hold_update_service.rb
@@ -1,58 +1,62 @@
 class ConfidentialHoldUpdateService
-  class InvalidActionLocality < StandardError; end
-  attr_accessor :author, :ldap_directory
-  attr_reader :updater
+  class << self
+    def update(author)
+      ldap_result = grab_ldap_results(author)
+      return if ldap_result.empty?
 
-  def initialize(author, action_locality, ldap_directory: LdapUniversityDirectory.new)
-    @updater = assign_updater(action_locality.to_s)
-    @author = author
-    @ldap_directory = ldap_directory
-  end
-
-  def update
-    ldap_result = grab_ldap_results
-    return if ldap_result.empty?
-
-    update_confidential_hold(ldap_result[:confidential_hold])
-  end
-
-  private
-
-    def grab_ldap_results
-      ldap_directory.retrieve(@author.access_id, 'uid', LdapResultsMap::AUTHOR_LDAP_MAP)
+      update_confidential_hold(author, ldap_result[:confidential_hold], 'login_controller')
     end
 
-    def update_confidential_hold(conf_hold_result)
-      if conf_hold_result == true && @author.confidential_hold == false
-        set_conf_hold
-        Rails.logger.info "#{@author.first_name} #{@author.last_name}'s confidential hold status was changed from 'false' to 'true'."
-      elsif conf_hold_result != true && @author.confidential_hold == true
-        remove_conf_hold
-        Rails.logger.info "#{@author.first_name} #{@author.last_name}'s confidential hold status was changed from 'true' to 'false'."
+    def update_all
+      LdapUniversityDirectory.new.with_connection do |connection|
+        base = Rails.application.config_for(:ldap)['base']
+        Author.find_each do |author|
+          attrs = []
+          attrs = connection.search(base: base,
+                                    filter: Net::LDAP::Filter.eq('uid', author.access_id), attributes: attrs)
+          mapped_attributes = LdapResult.new(ldap_record: attrs,
+                                             attribute_map: LdapResultsMap::AUTHOR_LDAP_MAP).map_directory_info
+          next {} if mapped_attributes.blank?
+
+          ldap_result = mapped_attributes.first
+          next if ldap_result.empty?
+
+          update_confidential_hold(author, ldap_result[:confidential_hold], 'rake_task')
+        end
       end
     end
 
-    def set_conf_hold
-      @author.attributes = { confidential_hold: true, confidential_hold_set_at: DateTime.now }
-      @author.confidential_hold_histories << ConfidentialHoldHistory.create(set_at: DateTime.now, set_by: updater)
-      @author.save(validate: false)
-    end
+    private
 
-    def remove_conf_hold
-      @author.attributes = { confidential_hold: false, confidential_hold_set_at: nil }
-      last_conf_hold = @author.confidential_hold_histories.last
-      if last_conf_hold.present?
-        last_conf_hold.attribtues = { removed_at: DateTime.now, removed_by: updater }
-      else
-        @author.confidential_hold_histories << ConfidentialHoldHistory.create(removed_at: DateTime.now, removed_by: updater)
-        @author.save(validate: false)
+      def grab_ldap_results(author)
+        LdapUniversityDirectory.new.retrieve(author.access_id, 'uid', LdapResultsMap::AUTHOR_LDAP_MAP)
       end
-    end
 
-    def assign_updater(action_locality)
-      localities = ['login_controller', 'rake_task']
-      raise InvalidActionLocality, "The value of the action_locality parameter must be in this list: #{localities}." unless localities.include? action_locality
+      def update_confidential_hold(author, conf_hold_result, location)
+        if conf_hold_result == true && author.confidential_hold == false
+          set_conf_hold(author, location)
+          Rails.logger.info "#{author.first_name} #{author.last_name}'s confidential hold status was changed from 'false' to 'true'."
+        elsif conf_hold_result != true && author.confidential_hold == true
+          remove_conf_hold(author, location)
+          Rails.logger.info "#{author.first_name} #{author.last_name}'s confidential hold status was changed from 'true' to 'false'."
+        end
+      end
 
-      action_locality
-    end
+      def set_conf_hold(author, location)
+        author.attributes = { confidential_hold: true, confidential_hold_set_at: DateTime.now }
+        author.confidential_hold_histories << ConfidentialHoldHistory.create(set_at: DateTime.now, set_by: location)
+        author.save(validate: false)
+      end
+
+      def remove_conf_hold(author, location)
+        author.attributes = { confidential_hold: false, confidential_hold_set_at: nil }
+        last_conf_hold = author.confidential_hold_histories.last
+        if last_conf_hold.present?
+          last_conf_hold.attributes = { removed_at: DateTime.now, removed_by: location }
+        else
+          author.confidential_hold_histories << ConfidentialHoldHistory.create(removed_at: DateTime.now, removed_by: location)
+          author.save(validate: false)
+        end
+      end
+  end
 end

--- a/app/services/confidential_hold_update_service.rb
+++ b/app/services/confidential_hold_update_service.rb
@@ -33,19 +33,19 @@ class ConfidentialHoldUpdateService
     end
 
     def set_conf_hold
-      @author.update! confidential_hold: true, confidential_hold_set_at: DateTime.now
+      @author.attributes = { confidential_hold: true, confidential_hold_set_at: DateTime.now }
       @author.confidential_hold_histories << ConfidentialHoldHistory.create(set_at: DateTime.now, set_by: updater)
-      @author.save!
+      @author.save(validate: false)
     end
 
     def remove_conf_hold
-      @author.update! confidential_hold: false, confidential_hold_set_at: nil
+      @author.attributes = { confidential_hold: false, confidential_hold_set_at: nil }
       last_conf_hold = @author.confidential_hold_histories.last
       if last_conf_hold.present?
-        last_conf_hold.update!(removed_at: DateTime.now, removed_by: updater)
+        last_conf_hold.attribtues = { removed_at: DateTime.now, removed_by: updater }
       else
         @author.confidential_hold_histories << ConfidentialHoldHistory.create(removed_at: DateTime.now, removed_by: updater)
-        @author.save!
+        @author.save(validate: false)
       end
     end
 

--- a/lib/tasks/confidential.rake
+++ b/lib/tasks/confidential.rake
@@ -20,7 +20,7 @@ namespace :confidential do
     start = Time.now
     directory = LdapUniversityDirectory.new
     Author.all.each do |author|
-      conf_hold_update_service = ConfidentialHoldUpdateService.new author, 'rake_task', directory
+      conf_hold_update_service = ConfidentialHoldUpdateService.new author, 'rake_task', ldap_directory: directory
       conf_hold_update_service.update
     end
     puts "Process completed in #{(Time.now - start)} sec."

--- a/lib/tasks/confidential.rake
+++ b/lib/tasks/confidential.rake
@@ -18,11 +18,7 @@ namespace :confidential do
   desc 'Update authors that have a confidential hold status in ldap'
   task update: :environment do
     start = Time.now
-    directory = LdapUniversityDirectory.new
-    Author.all.each do |author|
-      conf_hold_update_service = ConfidentialHoldUpdateService.new author, 'rake_task', ldap_directory: directory
-      conf_hold_update_service.update
-    end
+    ConfidentialHoldUpdateService.update_all
     puts "Process completed in #{(Time.now - start)} sec."
   end
 end

--- a/spec/services/confidential_hold_update_service_spec.rb
+++ b/spec/services/confidential_hold_update_service_spec.rb
@@ -55,9 +55,15 @@ RSpec.describe ConfidentialHoldUpdateService do
   end
 
   describe '#update_all' do
+    let!(:author2) { FactoryBot.create :author, confidential_hold: false, confidential_hold_set_at: nil }
+
     it 'updates confidential hold history with daily report metadata' do
+      allow(described_class).to receive(:ldap_result_connected).and_return({ confidential_hold: true })
       described_class.update_all
       expect(Author.find(author.id).confidential_hold_histories.first.set_by).to eq 'rake_task'
+      expect(Author.find(author.id).confidential_hold).to eq true
+      expect(Author.find(author2.id).confidential_hold_histories.first.set_by).to eq 'rake_task'
+      expect(Author.find(author2.id).confidential_hold).to eq true
     end
   end
 end


### PR DESCRIPTION
Revamped ConfidentialHoldUpdateService to have two public methods.  `#update` is like the original update method, however I removed all the initialization variables (basically made the class a module) and made `#update` receive an author arg.  `#update_all` loops through all authors within a single LDAP connection and does the confidential hold update without using the LdapUniversityDirectory `#retrieve` method.

The locality variables are set in the ConfidentialHoldUpdateService instead of being passed in as args during initialization.

Also, I moved the LdapUniversityDirectory `#with_connection` out into the public interface.