### PR TITLE
Handle Date conversion to utc

### DIFF
--- a/app/models/solr_submission.rb
+++ b/app/models/solr_submission.rb
@@ -50,32 +50,22 @@ class SolrSubmission < SimpleDelegator
     end
 
     def final_submission_files_uploaded_at_dtsi
-      if final_submission_files_uploaded_at.respond_to?(:getutc)
-        final_submission_files_uploaded_at.getutc
-      elsif final_submission_files_uploaded_at.respond_to?(:to_datetime)
-        final_submission_files_uploaded_at.to_datetime.getutc
-      else
-        nil
-      end
+      convert_to_utc(:final_submission_files_uploaded_at)
     end
 
     def released_metadata_at_dtsi
-      if released_metadata_at.respond_to?(:getutc)
-        released_metadata_at.getutc
-      elsif released_metadata_at.respond_to?(:to_datetime)
-        released_metadata_at.to_datetime.getutc
-      else
-        nil
-      end
+      convert_to_utc(:released_metadata_at)
     end
 
     def defended_at_dtsi
-      if defended_at.respond_to?(:getutc)
-        defended_at.getutc
-      elsif defended_at.respond_to?(:to_datetime)
-        defended_at.to_datetime.getutc
-      else
-        nil
+      convert_to_utc(:defended_at)
+    end
+
+    def convert_to_utc(attr)
+      if send(attr).respond_to?(:getutc)
+        send(attr).getutc
+      elsif send(attr).respond_to?(:to_datetime)
+        send(attr).to_datetime.getutc
       end
     end
 

--- a/app/models/solr_submission.rb
+++ b/app/models/solr_submission.rb
@@ -62,11 +62,9 @@ class SolrSubmission < SimpleDelegator
     end
 
     def convert_to_utc(attr)
-      if send(attr).respond_to?(:getutc)
-        send(attr).getutc
-      elsif send(attr).respond_to?(:to_datetime)
-        send(attr).to_datetime.getutc
-      end
+      return send(attr).getutc if send(attr).respond_to?(:getutc)
+
+      send(attr)&.to_datetime&.getutc
     end
 
     def committee_member_and_role

--- a/app/models/solr_submission.rb
+++ b/app/models/solr_submission.rb
@@ -50,15 +50,33 @@ class SolrSubmission < SimpleDelegator
     end
 
     def final_submission_files_uploaded_at_dtsi
-      final_submission_files_uploaded_at&.getutc
+      if final_submission_files_uploaded_at.respond_to?(:getutc)
+        final_submission_files_uploaded_at.getutc
+      elsif final_submission_files_uploaded_at.respond_to?(:to_datetime)
+        final_submission_files_uploaded_at.to_datetime.getutc
+      else
+        nil
+      end
     end
 
     def released_metadata_at_dtsi
-      released_metadata_at&.getutc
+      if released_metadata_at.respond_to?(:getutc)
+        released_metadata_at.getutc
+      elsif released_metadata_at.respond_to?(:to_datetime)
+        released_metadata_at.to_datetime.getutc
+      else
+        nil
+      end
     end
 
     def defended_at_dtsi
-      defended_at&.getutc
+      if defended_at.respond_to?(:getutc)
+        defended_at.getutc
+      elsif defended_at.respond_to?(:to_datetime)
+        defended_at.to_datetime.getutc
+      else
+        nil
+      end
     end
 
     def committee_member_and_role

--- a/spec/models/solr_submission_spec.rb
+++ b/spec/models/solr_submission_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe SolrSubmission, type: :model do
              legacy_id: 123,
              final_submission_legacy_old_id: 321,
              public_id: '1234abc32',
-             released_metadata_at: DateTime.now,
+             # Test that date converts to UTC datetime
+             released_metadata_at: Date.today,
+             # Test that datetime converts to UTC
              final_submission_files_uploaded_at: DateTime.now,
+             # Test that nil stays nil
              defended_at: nil
     end
     let(:final_submission_file_1) { create :final_submission_file }
@@ -61,7 +64,7 @@ RSpec.describe SolrSubmission, type: :model do
                                               "middle_name_ssi" => submission.author_middle_name,
                                               "program_name_ssi" => submission.program_name,
                                               "program_name_tesi" => submission.program_name,
-                                              "released_metadata_at_dtsi" => submission.released_metadata_at.getutc,
+                                              "released_metadata_at_dtsi" => submission.released_metadata_at.to_datetime.getutc,
                                               "semester_ssi" => submission.semester,
                                               "title_ssi" => submission.title,
                                               "title_tesi" => submission.title,


### PR DESCRIPTION
Logic in SolrSubmission to work with both dates and datetimes when converting to utc.  Test changes to test this.

closes #532 