### PR TITLE
wrap release_for_publication in a transaction for rollback

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -363,9 +363,9 @@ class Submission < ApplicationRecord
   end
 
   def self.release_for_publication(submission_ids, date_to_release, release_type)
-    # Submission.transaction do
-    SubmissionReleaseService.new.publish(submission_ids, date_to_release, release_type)
-    # end
+    Submission.transaction do
+      SubmissionReleaseService.new.publish(submission_ids, date_to_release, release_type)
+    end
   end
 
   def self.extend_publication_date(submission_ids, date_to_release)


### PR DESCRIPTION
I tested this in a branch, and it does what we need it to do. It was commented out back in 2018, i think maybe by accident? 

Addresses #544 