### PR TITLE
Hotfix: Degree Checkout Status update

### DIFF
--- a/app/models/lionpath/lionpath_program.rb
+++ b/app/models/lionpath/lionpath_program.rb
@@ -26,8 +26,11 @@ class Lionpath::LionpathProgram
   private
 
     def submission_update(submission, row)
-      submission.update submission_attrs(row) unless
-          submission.status_behavior.beyond_waiting_for_final_submission_response_rejected?
+      if !submission.status_behavior.beyond_waiting_for_final_submission_response_rejected?
+        submission.update submission_attrs(row)
+      elsif row['ChkoutStat'] != submission.degree_checkout_status
+        submission.update(degree_checkout_status: row['ChkoutStat'], lionpath_updated_at: DateTime.now)
+      end
     end
 
     def submission_attrs(row)

--- a/spec/models/lionpath/lionpath_program_spec.rb
+++ b/spec/models/lionpath/lionpath_program_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe Lionpath::LionpathProgram do
   context 'when submission already exists' do
     let!(:author) { FactoryBot.create :author, psu_idn: '999999999', access_id: 'xxb13' }
     let!(:program) { FactoryBot.create :program, code: row_1['Acadademic Plan'] }
-    let!(:submission) { FactoryBot.create :submission, author: author, degree: degree, program: program }
+    let!(:submission) do
+      FactoryBot.create :submission, author: author, degree: degree, program: program, degree_checkout_status: nil
+    end
 
     it 'updates the submission' do
       expect { lionpath_program.import(row_1) }.to change(Submission, :count).by 0
@@ -89,15 +91,31 @@ RSpec.describe Lionpath::LionpathProgram do
       expect(Author.first.submissions.first.campus).to eq('UP')
     end
 
-    context 'when submission is already beyond_waiting_for_final_submission_response_rejected?' do
-      it 'does not update program info' do
-        submission.update status: 'waiting for publication release'
-        submission.reload
-        expect { lionpath_program.import(row_1) }.not_to(change { Submission.find(submission.id).lionpath_updated_at })
-        expect(Author.first.submissions.first.degree.name).to eq submission.degree.name
-        expect(Author.first.submissions.first.lionpath_year).to eq submission.lionpath_year
-        expect(Author.first.submissions.first.lionpath_semester).to eq submission.lionpath_semester
-        expect(Author.first.submissions.first.campus).to eq submission.campus
+
+    context 'when submission is beyond_waiting_for_final_submission_response_rejected?' do
+      context 'when degree checkout status is unchanged' do
+        it 'does not update program info' do
+          submission.update status: 'waiting for publication release', degree_checkout_status: 'EG'
+          submission.reload
+          expect { lionpath_program.import(row_1) }.not_to(change { Submission.find(submission.id).lionpath_updated_at })
+          expect(Author.first.submissions.first.degree.name).to eq submission.degree.name
+          expect(Author.first.submissions.first.lionpath_year).to eq submission.lionpath_year
+          expect(Author.first.submissions.first.lionpath_semester).to eq submission.lionpath_semester
+          expect(Author.first.submissions.first.degree_checkout_status).to eq submission.degree_checkout_status
+        end
+      end
+
+      context "when submission's #degree_checkout_status does not equal degree checkout status from LP" do
+        it 'only updates #degree_checkout_status and #lionpath_updated_at' do
+          submission.update status: 'waiting for publication release'
+          submission.reload
+          expect { lionpath_program.import(row_1) }.to(change { Submission.find(submission.id).lionpath_updated_at })
+          expect(Author.first.submissions.first.degree.name).to eq submission.degree.name
+          expect(Author.first.submissions.first.lionpath_year).to eq submission.lionpath_year
+          expect(Author.first.submissions.first.lionpath_semester).to eq submission.lionpath_semester
+          expect(Author.first.submissions.first.campus).to eq submission.campus
+          expect(Author.first.submissions.first.degree_checkout_status).to eq row_1['ChkoutStat']
+        end
       end
     end
   end

--- a/spec/models/lionpath/lionpath_program_spec.rb
+++ b/spec/models/lionpath/lionpath_program_spec.rb
@@ -91,7 +91,6 @@ RSpec.describe Lionpath::LionpathProgram do
       expect(Author.first.submissions.first.campus).to eq('UP')
     end
 
-
     context 'when submission is beyond_waiting_for_final_submission_response_rejected?' do
       context 'when degree checkout status is unchanged' do
         it 'does not update program info' do


### PR DESCRIPTION
Update submission #degree_checkout_status during student plan import if past review stage but degree checkout status has changed.  Tests for this.