### PR TITLE
dd tracer env

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -6,6 +6,7 @@ if Rails.env == 'production'
         c.use :redis, service_name: "#{release_name}-redis"
         c.use :active_record, service_name: "#{release_name}-active-record"
         c.use :sidekiq, service_name: "#{release_name}-sidekiq"
+        c.tracer env: ENV['DD_ENV']
     end
 end
 


### PR DESCRIPTION
- sets DD_ENV

in etda-config when we set datadog.enabled -- we'll set the DD_AGENT_HOST env var, this tells datadog where to send traces to. we also set DD_ENV so we can filter based off `env:` in datadog