### PR TITLE
Yarnkey

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:experimental
-FROM harbor.k8s.libraries.psu.edu/library/ruby-2.7.6-node-12:20230116 as base
+FROM harbor.k8s.libraries.psu.edu/library/ruby-2.7.6-node-12:20230126 as base
 
 # hadolint ignore=DL3008
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /usr/share/keyrings/yarn-keyring.asc \
-    && sed -i '1s;^deb;deb [signed-by=/usr/share/keyrings/yarn-keyring.asc];' /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && \ 
   apt-get install --no-install-recommends libmariadb-dev mariadb-client clamav clamdscan wget libpng-dev make -y && \
   rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM harbor.k8s.libraries.psu.edu/library/ruby-2.7.6-node-12:20230116 as base
 
 # hadolint ignore=DL3008
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /usr/share/keyrings/yarn-keyring.asc \
+    && sed -i '1s;^deb;deb [signed-by=/usr/share/keyrings/yarn-keyring.asc];' /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && \ 
   apt-get install --no-install-recommends libmariadb-dev mariadb-client clamav clamdscan wget libpng-dev make -y && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Builds were failing and it had something to do with a public key for yarn.  The discussion and work-around for this is in the yarn repo here: https://github.com/yarnpkg/yarn/issues/7866 .  I grabbed the work-around and lobbed it in our Dockerfile.