### PR TITLE
Adds caching to remote docker to fix failing Circle CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
     - setup_remote_docker:
         version: 20.10.6
+        docker_layer_caching: true
     - checkout
     # - restore_cache:
     #     keys:
@@ -64,6 +65,7 @@ jobs:
         at: /tmp/workspace
     - setup_remote_docker:
         version: 20.10.6
+        docker_layer_caching: true
     - checkout
     - run:
         name: "Rubocop"
@@ -83,6 +85,7 @@ jobs:
         at: /tmp/workspace
     - setup_remote_docker:
         version: 20.10.6
+        docker_layer_caching: true
     - checkout
     - run:
         name: "Integration Test Graduate"
@@ -110,6 +113,7 @@ jobs:
           at: /tmp/workspace
       - setup_remote_docker:
           version: 20.10.6
+          docker_layer_caching: true
       - checkout
       - run:
           name: "Unit Test Graduate"
@@ -135,6 +139,7 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 20.10.6
+          docker_layer_caching: true
       - checkout
       - attach_workspace:
           at: /tmp/workspace
@@ -173,6 +178,7 @@ jobs:
         at: /tmp/workspace
     - setup_remote_docker:
         version: 20.10.6
+        docker_layer_caching: true
     - checkout
     - run:
         name: "Setup Workspace"


### PR DESCRIPTION
This seems to do the trick.  My not-an-expert assumption as to why would be that the caching reduces overhead for builds following the initial build.  This stops them from exceeding the 8G of memory.  This may just be a temporary fix and it would be worth evaluating the whole ETDA Workflow CI configuration sometime in the future.