### PR TITLE
Error messages fix

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -3,8 +3,8 @@
     <div class="col-xs-12">
       <div class="alert alert-danger" role="alert" aria-labelledby="alert-message">
         <ul>
-          <% for message in object.errors.values %>
-            <li><%= message.first %></li>
+          <% object.errors.each do |error| %>
+            <li><%= error.message %></li>
           <% end %>
         </ul>
       </div>

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -153,5 +153,18 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
         expect(submission.final_submission_files_uploaded_at).not_to be_nil
       end
     end
+
+    context 'when an ActiveRecord validation error occurs' do
+      it 'displays error messages' do
+        visit author_submission_edit_final_submission_path(submission)
+        click_button 'Submit final files for review'
+        within('.alert-danger') do
+          expect(page).to have_content 'You must upload a Final Submission File'
+          expect(page).to have_content "Abstract can't be blank"
+          expect(page).to have_content "If you agree to the copyright terms, please check the box to submit"
+          expect(page).to have_content "Proquest agreement can't be blank"
+        end
+      end
+    end
   end
 end

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -162,7 +162,6 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
           expect(page).to have_content 'You must upload a Final Submission File'
           expect(page).to have_content "Abstract can't be blank"
           expect(page).to have_content "If you agree to the copyright terms, please check the box to submit"
-          expect(page).to have_content "Proquest agreement can't be blank"
         end
       end
     end


### PR DESCRIPTION
The error messages on the final submission page were just returning the first letter of the message:
![Screenshot 2023-03-24 at 11 07 09 AM](https://user-images.githubusercontent.com/32677188/227565205-65258578-919c-4854-8d0e-48597de27b52.png)
The way the ActiveRecord errors are being stored must've changed with the new Rails version.  `errors.values` is deprecated in Rails 7 anyways.  I changed the way we are grabbing and displaying the errors to fix the issue.  Also, added a test for his.