### PR TITLE
Deprecated errors.values changed to errors.collect(&:message)

### DIFF
--- a/app/controllers/admin/approval_configurations_controller.rb
+++ b/app/controllers/admin/approval_configurations_controller.rb
@@ -15,7 +15,7 @@ class Admin::ApprovalConfigurationsController < AdminController
     redirect_to admin_approval_configurations_path
     flash[:notice] = 'Approval Configuration successfully updated'
   rescue ActiveRecord::RecordInvalid => e
-    flash[:error] = e.record.errors.values.join(" ")
+    flash[:error] = e.record.errors.collect(&:message).join(" ")
     render :edit
   end
 

--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -19,7 +19,7 @@ class Admin::AuthorsController < AdminController
     redirect_to admin_authors_path
     flash[:notice] = 'Author successfully updated'
   rescue ActiveRecord::RecordInvalid => e
-    flash[:error] = e.record.errors.values.join(" ")
+    flash[:error] = e.record.errors.collect(&:message).join(" ")
     render :edit
   end
 

--- a/app/controllers/approver/approvers_controller.rb
+++ b/app/controllers/approver/approvers_controller.rb
@@ -35,7 +35,7 @@ class Approver::ApproversController < ApproverController
     redirect_to approver_root_path
     flash[:notice] = 'Review submitted successfully'
   rescue ActiveRecord::RecordInvalid => e
-    flash[:error] = e.record.errors.values.join(" ")
+    flash[:error] = e.record.errors.collect(&:message).join(" ")
     redirect_to approver_path(params[:id])
   end
 

--- a/app/controllers/author/authors_controller.rb
+++ b/app/controllers/author/authors_controller.rb
@@ -23,7 +23,7 @@ class Author::AuthorsController < AuthorController
     redirect_to author_root_path
     flash[:notice] = 'Contact information updated successfully'
   rescue ActiveRecord::RecordInvalid => e
-    flash.now[:alert] = e.record.errors.values.join(" ")
+    flash.now[:alert] = e.record.errors.collect(&:message).join(" ")
     render :edit
   rescue Author::NotAuthorizedToEdit
     redirect_to '/401'

--- a/app/controllers/author/committee_members_controller.rb
+++ b/app/controllers/author/committee_members_controller.rb
@@ -19,7 +19,7 @@ class Author::CommitteeMembersController < AuthorController
     flash[:notice] = 'Committee saved successfully'
     redirect_to author_root_path
   rescue ActiveRecord::RecordInvalid => e
-    flash[:alert] = e.record.errors.values.join(" ")
+    flash[:alert] = e.record.errors.collect(&:message).join(" ")
     render :new
   rescue SubmissionStatusGiver::AccessForbidden
     flash.now[:alert] = 'You are not allowed to visit that page at this time, please contact your administrator'
@@ -46,7 +46,7 @@ class Author::CommitteeMembersController < AuthorController
       redirect_to edit_author_submission_committee_members_path(@submission)
     end
   rescue ActiveRecord::RecordInvalid => e
-    flash[:alert] = e.record.errors.values.join(" ")
+    flash[:alert] = e.record.errors.collect(&:message).join(" ")
     render :form
   rescue SubmissionStatusGiver::AccessForbidden
     flash[:alert] = 'You are not allowed to visit that page at this time, please contact your administrator'


### PR DESCRIPTION
`errors.values` will be deprecated in Rails 7.  

Even though this isn't deprecated yet, it was causing issues in other parts of the code.  That was fixed in another PR.  These seem to still be working in this PR, but just to be safe I think it makes sense to fix them now.