### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
+    resource_class: large
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -93,8 +94,6 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-          docker-compose up -d db selenium redis
-          sleep 10
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -110,6 +109,7 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -123,8 +123,6 @@ jobs:
             docker load -i /tmp/workspace/etda-workflow.tar
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-            docker-compose up -d db selenium redis
-            sleep 10
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -177,6 +175,7 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
+    resource_class: large
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -193,24 +192,18 @@ jobs:
     - run:
         name: "Test Honors"
         command: |
-          docker-compose up -d db selenium redis
-          sleep 10
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test Milsch"
         command: |
-          docker-compose up -d db selenium redis
-          sleep 5
           PARTNER=milsch docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test SSET"
         command: |
-          docker-compose up -d db selenium redis
-          sleep 5
           PARTNER=sset docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-          docker-compose up -d redis db selenium
+          docker-compose up -d db selenium
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -122,6 +122,7 @@ jobs:
             docker load -i /tmp/workspace/etda-workflow.tar
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+            docker-compose up -d db selenium
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -190,18 +191,21 @@ jobs:
     - run:
         name: "Test Honors"
         command: |
+          docker-compose up -d db selenium
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test Milsch"
         command: |
+          docker-compose up -d db selenium
           PARTNER=milsch docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test SSET"
         command: |
+          docker-compose up -d db selenium
           PARTNER=sset docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+          sleep 20
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+          docker-compose up -d redis db selenium
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
-          sleep 10
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
           /tmp/workspace/cc-test-reporter format-coverage -t simplecov -o integration_coverage.json -p /etda_workflow/ .resultset.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,8 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-          echo 'sleeping for 30 seconds'
-          sleep 30
-          echo 'done sleeping'
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
+          sleep 10
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
           /tmp/workspace/cc-test-reporter format-coverage -t simplecov -o integration_coverage.json -p /etda_workflow/ .resultset.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
           docker-compose up -d db selenium redis
-          sleep 5
+          sleep 10
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -124,7 +124,7 @@ jobs:
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
             docker-compose up -d db selenium redis
-            sleep 5
+            sleep 10
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -194,7 +194,7 @@ jobs:
         name: "Test Honors"
         command: |
           docker-compose up -d db selenium redis
-          sleep 5
+          sleep 10
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,9 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-          sleep 20
+          echo 'sleeping for 30 seconds'
+          sleep 30
+          echo 'done sleeping'
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-          docker-compose up -d db selenium
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -122,7 +121,6 @@ jobs:
             docker load -i /tmp/workspace/etda-workflow.tar
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
-            docker-compose up -d db selenium
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -191,21 +189,18 @@ jobs:
     - run:
         name: "Test Honors"
         command: |
-          docker-compose up -d db selenium
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test Milsch"
         command: |
-          docker-compose up -d db selenium
           PARTNER=milsch docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test SSET"
         command: |
-          docker-compose up -d db selenium
           PARTNER=sset docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -121,6 +123,8 @@ jobs:
             docker load -i /tmp/workspace/etda-workflow.tar
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+            docker-compose up -d db selenium redis
+            sleep 5
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -189,18 +193,24 @@ jobs:
     - run:
         name: "Test Honors"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test Milsch"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=milsch docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test SSET"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=sset docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
-    resource_class: large
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -94,6 +93,8 @@ jobs:
           docker load -i /tmp/workspace/etda-workflow.tar
           export TAG=${CIRCLE_SHA1}
           export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+          docker-compose up -d db selenium redis
+          sleep 10
           PARTNER=graduate docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test -e INTEGRATION=true test /etda_workflow/bin/ci-rspec
           docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -109,7 +110,6 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
-    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -123,6 +123,8 @@ jobs:
             docker load -i /tmp/workspace/etda-workflow.tar
             export TAG=${CIRCLE_SHA1}
             export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+            docker-compose up -d db selenium redis
+            sleep 10
             PARTNER=graduate docker-compose run --name=test --service-ports -d test
             docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
             docker cp test:/etda_workflow/coverage/.resultset.json .resultset.json
@@ -175,7 +177,6 @@ jobs:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
       REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/etda-workflow
-    resource_class: large
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -192,18 +193,24 @@ jobs:
     - run:
         name: "Test Honors"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 10
           PARTNER=honors docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test Milsch"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=milsch docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down
     - run:
         name: "Test SSET"
         command: |
+          docker-compose up -d db selenium redis
+          sleep 5
           PARTNER=sset docker-compose run --name=test --service-ports -d test
           docker exec -e RAILS_ENV=test test /etda_workflow/bin/ci-rspec
           docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     depends_on:
     - db
     - selenium
+    - redis
     # volumes:
     # - workflow_files:/etda_workflow/tmp/workflow_files
     # - explore_files:/etda_workflow/tmp/explore_files


### PR DESCRIPTION
I'm not 100% sure what's going on here.  There seemed to be a delay with the db container booting up, so the test container was not connecting to db.  The parallel runs may be competing for resources, and could be causing a delay?  Adding some sleeps between running the dependent containers and the test container fixes this.  Increasing the resource classes did not work.

The builds have been building much faster lately.  Not sure if CircleCI has been doing some changes/upgrades to their docker environments.  Even with these sleeps added, the time for the entire workflow to finish is down significantly.  It takes about 21 minutes.