### PR TITLE
removes redis check. sidekiq also connects to redis

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -28,9 +28,3 @@ sidekiq_config['queues'].each do |q|
     threshold = sidekiq_config['size_threshold'] || 100
     OkComputer::Registry.register "sidekiq_size_#{q}", SidekiqQueueCheck.new(q, threshold=threshold)
 end
-
-## Redis Checks 
-
-redis_config = Rails.application.config_for(:redis)
-
-OkComputer::Registry.register "redis", OkComputer::RedisCheck.new(redis_config)


### PR DESCRIPTION
The OkComputer redis check uses `redis-rb` under the covers, to continue with `redis-client` we'd have to rewrite the healthchecks ourselves. 

Since we also check sidekiq, and sidekiq connects to redis -- the sidekiq checks should also cover us in the event of a redis failure. I will also update our nagios checks to use the `/all` endpoint instead of the `/redis` endpoint so that we get alerted on sidekiq failueres