### PR TITLE
Hotfix: Prevent email reminders from going out beyond the committee review stage

### DIFF
--- a/app/workers/committee_reminder_worker.rb
+++ b/app/workers/committee_reminder_worker.rb
@@ -9,7 +9,7 @@ class CommitteeReminderWorker
 
     return unless committee_member.reminder_email_authorized?
 
-    return if committee_member.status.present? || submission.status_behavior.waiting_for_committee_review_rejected?
+    return if committee_member.status.present? || submission.status_behavior.beyond_waiting_for_head_of_program_review?
 
     WorkflowMailer.send_committee_review_reminders(submission, committee_member)
   end

--- a/app/workers/committee_reminder_worker.rb
+++ b/app/workers/committee_reminder_worker.rb
@@ -9,7 +9,7 @@ class CommitteeReminderWorker
 
     return unless committee_member.reminder_email_authorized?
 
-    return if committee_member.status == 'approved' || committee_member.status == 'rejected'
+    return if committee_member.status.present? || submission.status_behavior.waiting_for_committee_review_rejected?
 
     WorkflowMailer.send_committee_review_reminders(submission, committee_member)
   end

--- a/spec/workers/committee_reminder_worker_spec.rb
+++ b/spec/workers/committee_reminder_worker_spec.rb
@@ -43,9 +43,13 @@ RSpec.describe CommitteeReminderWorker do
     end
   end
 
-  context "when submission is in the 'waiting for committee review rejected' stage" do
+  context "when submission is beyond_waiting_for_head_of_program_review?" do
     it 'does not deliver an email' do
       submission.update status: 'waiting for committee review rejected'
+      Sidekiq::Testing.inline! do
+        expect { described_class.perform_async(submission.id, committee_member.id) }.to change { WorkflowMailer.deliveries.size }.by(0)
+      end
+      submission.update status: 'waiting for final submission response'
       Sidekiq::Testing.inline! do
         expect { described_class.perform_async(submission.id, committee_member.id) }.to change { WorkflowMailer.deliveries.size }.by(0)
       end


### PR DESCRIPTION
This includes the committee rejected stage.  Also, prevent email reminders when committee member has any kind of vote.

Origin: https://pennstate.service-now.com/nav_to.do?uri=%2Fincident.do%3Fsys_id%3D7a5b1da697dc4a943dbab577f053af3e%26sysparm_stack%3Dincident_list.do%3Fsysparm_query%3Dactive%3Dtrue

Basically, a committee member received a reminder email when the submission was in the rejected stage.