### PR TITLE
"Honors Advisor" to "Thesis Honors Advisor"

### DIFF
--- a/app/models/committee_role.rb
+++ b/app/models/committee_role.rb
@@ -29,8 +29,7 @@ class CommitteeRole < ApplicationRecord
 
   HONORS_ROLES = { 'thesis' => [
     { name: 'Thesis Supervisor',       num_required: 1, is_active: true, is_program_head: false },
-    { name: 'Honors Advisor',          num_required: 1, is_active: true, is_program_head: false },
-    { name: 'Thesis Honors Advisor',   num_required: 0, is_active: true, is_program_head: false },
+    { name: 'Thesis Honors Advisor',   num_required: 1, is_active: true, is_program_head: false },
     { name: 'Faculty Reader',          num_required: 0, is_active: true, is_program_head: false }
   ] }.freeze
 

--- a/app/views/author/technical_tips.html.erb
+++ b/app/views/author/technical_tips.html.erb
@@ -52,7 +52,7 @@
     <ul>
         <li>For dissertation candidates, committees are imported entirely from LionPATH.  If changes are needed, make those changes in LionPATH.  Your committee will update in the eTD system after one day.</li>
         <li>For master’s thesis candidates, there must be at least one Thesis Advisor. If there is more than one, they must be added as a Co-Advisor.  The Program Head/Chair is imported from LionPATH.</li>
-        <li>For honors thesis candidates, there must be at least one Thesis Supervisor and one Honors Advisor.</li>
+        <li>For honors thesis candidates, there must be at least one Thesis Supervisor and one Thesis Honors Advisor.</li>
         <li>For Millennium Scholars, there must be at least one thesis supervisor.</li>
         <li>For The School of Science, Engineering, and Technology, there must be at least one Paper Instructor (Advisor), one Paper Reader, and a Department Head.</li>
     </ul>

--- a/config/locales/partners/en/honors/honors.en.yml
+++ b/config/locales/partners/en/honors/honors.en.yml
@@ -237,9 +237,9 @@ en:
               description: Faculty member who oversees the thesis work and confirms it is indeed honors work in their area of expertise.
             faculty_reader:
               name: Faculty Reader
-              description: This role is only required if the Honors Advisor and Thesis Supervisor are the same person.  This is a faculty member in the discipline in which the thesis is written.
+              description: This role is only required if the Thesis Honors Advisor and Thesis Supervisor are the same person.  This is a faculty member in the discipline in which the thesis is written.
       author_instructions:
-        The honors college only requires two people to read and approve the thesis, an Honors Advisor and Thesis Supervisor. The only time a "Faculty Reader" is required is if the honors advisor and thesis supervisor are the same person.
+        The honors college only requires two people to read and approve the thesis, a Thesis Honors Advisor and Thesis Supervisor. The only time a "Faculty Reader" is required is if the honors advisor and thesis supervisor are the same person.
       special_role: supervisor
     admin_filters:
       format_review_incomplete:

--- a/spec/fixtures/legacy/committee_roles.yml
+++ b/spec/fixtures/legacy/committee_roles.yml
@@ -41,7 +41,7 @@ honors:
    is_active: true
    degree_type_id: 1
  - id: 2
-   name: "Honors Advisor"
+   name: "Thesis Honors Advisor"
    num_required: 1
    is_active: true
    degree_type_id: 1

--- a/spec/fixtures/legacy/committee_roles.yml
+++ b/spec/fixtures/legacy/committee_roles.yml
@@ -41,7 +41,7 @@ honors:
    is_active: true
    degree_type_id: 1
  - id: 2
-   name: "Thesis Honors Advisor"
+   name: "Honors Advisor"
    num_required: 1
    is_active: true
    degree_type_id: 1


### PR DESCRIPTION
Changed 'Honors Advisor' to 'Thesis Honors Advisor' for all instances relating to the honors college.

fixes #751 