### PR TITLE
651 - replaces "dissertation" with a dynamic submission type

### DIFF
--- a/app/views/shared/_federal_funding_checkbox.html.erb
+++ b/app/views/shared/_federal_funding_checkbox.html.erb
@@ -10,6 +10,6 @@
                               indicating that the findings and conclusions do not necessarily reflect the
                               view of the funding agency. [Please see the Research Terms Clarification to
                               2CFR § 200.328 (pp. 20-21) for the precise language to be used.]", true],
-                              ['I confirm that no federal funds were used for the work described in this
-                              dissertation.',false]]%>
+                              ["I confirm that no federal funds were used for the work described in this
+                              #{@submission.degree.degree_type.name.to_s.downcase}.",false]]%>
 </div>


### PR DESCRIPTION
Now the federal funding checkbox says "Dissertation" for graduate students and "Master Thesis" for masters students.