### PR TITLE
Wording change for email admins in approval configuration and adds hint

### DIFF
--- a/app/views/admin/approval_configurations/_form.html.erb
+++ b/app/views/admin/approval_configurations/_form.html.erb
@@ -32,7 +32,8 @@
     </div>
   <% end %>
 
-  <%= f.label :email_admins, '<strong>Email admins</strong>'.html_safe %>
+  <%= f.label :email_admins, '<strong>Email admins when committee rejects</strong>'.html_safe %>
+  <p class="hint">*Allow an email to be sent to admins when a committee rejects a submission.</p>
   <div class="row">
     <div class="col-sm-3">
       <%= f.input :email_admins, as: :radio_buttons,


### PR DESCRIPTION
fixes #731 

Also, I double-checked to make sure this toggle is only for the emails sent when a committee rejects (it is).