### PR TITLE
updates dissertation language

### DIFF
--- a/app/presenters/admin/submissions_dashboard_view.rb
+++ b/app/presenters/admin/submissions_dashboard_view.rb
@@ -166,10 +166,20 @@ class Admin::SubmissionsDashboardView
     end
 
     def title_for(index_view_scope)
-      I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.title")
+      thesis_title = I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.thesis_title")
+      if @degree_type.slug == 'master_thesis' && !thesis_title.match?(/Translation missing/)
+        thesis_title
+      else
+        I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.title")
+      end
     end
 
     def description_for(index_view_scope)
-      I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.description")
+      thesis_description = I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.thesis_description")
+      if @degree_type.slug == 'master_thesis' && !thesis_description.match?(/Translation missing/)
+        thesis_description
+      else
+        I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.description")
+      end
     end
 end

--- a/app/presenters/admin/submissions_dashboard_view.rb
+++ b/app/presenters/admin/submissions_dashboard_view.rb
@@ -166,20 +166,12 @@ class Admin::SubmissionsDashboardView
     end
 
     def title_for(index_view_scope)
-      thesis_title = I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.thesis_title")
-      if @degree_type.slug == 'master_thesis' && !thesis_title.match?(/Translation missing/)
-        thesis_title
-      else
-        I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.title")
-      end
+      submission = @degree_type.slug == 'dissertation' ? 'Dissertations' : 'Theses'
+      I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.title", submission:)
     end
 
     def description_for(index_view_scope)
-      thesis_description = I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.thesis_description")
-      if @degree_type.slug == 'master_thesis' && !thesis_description.match?(/Translation missing/)
-        thesis_description
-      else
-        I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.description")
-      end
+      submission = @degree_type.slug == 'dissertation' ? 'dissertations' : 'theses'
+      I18n.t("#{current_partner.id}.admin_filters.#{index_view_scope}.description", submission:).upcase_first
     end
 end

--- a/app/presenters/admin/submissions_index_view.rb
+++ b/app/presenters/admin/submissions_index_view.rb
@@ -23,7 +23,8 @@ class Admin::SubmissionsIndexView
   end
 
   def title
-    I18n.t("#{translation_key}.title")
+    submission = @degree_type.slug == 'dissertation' ? 'Dissertations' : 'Theses'
+    I18n.t("#{translation_key}.title", submission:)
   end
 
   def id

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -360,19 +360,23 @@ en:
         description: Draft submissions without format review files or were rejected and need formatting corrections
       format_review_submitted:
         title: Format Review is Submitted
-        description: Thesis drafts to be reviewed
+        thesis_description: Thesis drafts to be reviewed
+        description: Dissertation drafts to be reviewed
       format_review_completed:
         title: Format Review is Completed
         description: Completed and approved drafts
       final_submission_pending:
         title: Final Submission is Pending
-        description: Theses waiting to be reviewed by committee members
+        thesis_description: Theses waiting to be reviewed by committee members
+        description: Dissertations waiting to be reviewed by committee members
       committee_review_rejected:
         title: Committee Review Rejected
-        description: Theses rejected by committee
+        thesis_description: Theses rejected by committee
+        description: Dissertations rejected by committee
       final_submission_submitted:
         title: Final Submission is Submitted
-        description: Theses waiting to be reviewed for final formatting approval by the Graduate School
+        thesis_description: Theses waiting to be reviewed for final formatting approval by the Graduate School
+        description: Dissertations waiting to be reviewed for final formatting approval by the Graduate School
       final_submission_incomplete:
         title: Final Submission is Incomplete
         description: Submissions that were rejected and need formatting corrections
@@ -386,13 +390,17 @@ en:
         title: Final Submission is On Hold
         description: Submissions that have been approved but are now being held from release
       released_for_publication:
-        title: Released Theses
-        description: Manage theses which have already been released
+        thesis_title: Released Theses
+        thesis_description: Manage theses which have already been released
+        title: Released Dissertations
+        description: Manage dissertations which have already been released
       final_restricted_institution:
         title: Final Submission is Restricted to Penn State
         description: Submissions restricted to the Penn State community
       final_withheld:
-        title: Restricted Theses
+        thesis_title: Restricted Theses
+        thesis_description: Availability restricted for 2 years.
+        title: Restricted Dissertations
         description: Availability restricted for 2 years.
     access_level:
       open_access: Open Access

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -360,23 +360,19 @@ en:
         description: Draft submissions without format review files or were rejected and need formatting corrections
       format_review_submitted:
         title: Format Review is Submitted
-        thesis_description: Thesis drafts to be reviewed
-        description: Dissertation drafts to be reviewed
+        description: Draft %{submission} to be reviewed
       format_review_completed:
         title: Format Review is Completed
         description: Completed and approved drafts
       final_submission_pending:
         title: Final Submission is Pending
-        thesis_description: Theses waiting to be reviewed by committee members
-        description: Dissertations waiting to be reviewed by committee members
+        description: '%{submission} waiting to be reviewed by committee members'
       committee_review_rejected:
         title: Committee Review Rejected
-        thesis_description: Theses rejected by committee
-        description: Dissertations rejected by committee
+        description: '%{submission} rejected by committee'
       final_submission_submitted:
         title: Final Submission is Submitted
-        thesis_description: Theses waiting to be reviewed for final formatting approval by the Graduate School
-        description: Dissertations waiting to be reviewed for final formatting approval by the Graduate School
+        description: '%{submission} waiting to be reviewed for final formatting approval by the Graduate School'
       final_submission_incomplete:
         title: Final Submission is Incomplete
         description: Submissions that were rejected and need formatting corrections
@@ -391,16 +387,13 @@ en:
         description: Submissions that have been approved but are now being held from release
       released_for_publication:
         thesis_title: Released Theses
-        thesis_description: Manage theses which have already been released
-        title: Released Dissertations
-        description: Manage dissertations which have already been released
+        title: Released %{submission}
+        description: Manage %{submission} which have already been released
       final_restricted_institution:
         title: Final Submission is Restricted to Penn State
         description: Submissions restricted to the Penn State community
       final_withheld:
-        thesis_title: Restricted Theses
-        thesis_description: Availability restricted for 2 years.
-        title: Restricted Dissertations
+        title: Restricted %{submission}
         description: Availability restricted for 2 years.
     access_level:
       open_access: Open Access

--- a/spec/integration/admin/manage_submissions_spec.rb
+++ b/spec/integration/admin/manage_submissions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Manage Submissions", type: :integration, js: true do
       end
 
       it 'does not have a delete button but has other bulk actions' do
-        expect(page).to have_content('Restricted Theses')
+        expect(page).to have_content('Restricted Dissertations')
         expect(page).to have_content('Showing')
         expect(page).not_to have_selector('div#approved-final-submission-submissions-index_processing', visible: false)
         find_button('Select Visible').click
@@ -96,7 +96,7 @@ RSpec.describe "Manage Submissions", type: :integration, js: true do
       end
 
       it 'does not have bulk buttons when nothing is selected' do
-        expect(page).to have_content('Released Theses')
+        expect(page).to have_content('Released Dissertations')
         expect(page).to have_content('Showing')
         expect(page).not_to have_content('Bulk Actions')
         expect(page).not_to have_button('Select Visible')

--- a/spec/integration/admin/submissions/restricted_releases_spec.rb
+++ b/spec/integration/admin/submissions/restricted_releases_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "when an admin releases a restricted submission for publication a
       visit admin_submissions_index_path(DegreeType.default, 'final_withheld')
       sleep 1
       click_button 'Select Visible'
-      expect(page).to have_content(I18n.t("#{current_partner.id}.admin_filters.final_withheld.title"), wait: 5)
+      expect(page).to have_content(I18n.t("#{current_partner.id}.admin_filters.final_withheld.title", submission: 'Dissertations'), wait: 5)
       msg = page.accept_confirm do
         click_button 'Release as Open Access'
       end

--- a/spec/presenters/admin/submissions_dashboard_view_spec.rb
+++ b/spec/presenters/admin/submissions_dashboard_view_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Admin::SubmissionsDashboardView do
           {
             id: 'format-review-submitted',
             title: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.thesis_description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.description", submission: 'theses'),
             path: nil,
             count: nil
           },
@@ -60,21 +60,21 @@ RSpec.describe Admin::SubmissionsDashboardView do
           {
             id: 'final-submission-pending',
             title: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.thesis_description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.description", submission: 'Theses'),
             path: nil,
             count: nil
           },
           {
             id: 'committee-review-rejected',
             title: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.thesis_description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.description", submission: 'Theses'),
             path: nil,
             count: nil
           },
           {
             id: 'final-submission-submitted',
             title: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.thesis_description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.description", submission: 'Theses'),
             path: nil,
             count: nil
           },
@@ -101,8 +101,8 @@ RSpec.describe Admin::SubmissionsDashboardView do
           },
           {
             id: 'released-for-publication',
-            title: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.thesis_title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.thesis_description"),
+            title: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.title", submission: 'Theses'),
+            description: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.description", submission: 'theses'),
             path: nil,
             count: nil
           },
@@ -116,8 +116,8 @@ RSpec.describe Admin::SubmissionsDashboardView do
           },
           {
             id: 'final-withheld',
-            title: I18n.t("#{current_partner.id}.admin_filters.final_withheld.thesis_title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.final_withheld.thesis_description"),
+            title: I18n.t("#{current_partner.id}.admin_filters.final_withheld.title", submission: 'Theses'),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_withheld.description"),
             path: nil,
             count: nil,
             sub_count: nil
@@ -139,7 +139,7 @@ RSpec.describe Admin::SubmissionsDashboardView do
           {
             id: 'format-review-submitted',
             title: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.description", submission: 'dissertations'),
             path: nil,
             count: nil
           },
@@ -153,21 +153,21 @@ RSpec.describe Admin::SubmissionsDashboardView do
           {
             id: 'final-submission-pending',
             title: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.description", submission: 'Dissertations'),
             path: nil,
             count: nil
           },
           {
             id: 'committee-review-rejected',
             title: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.description"),
+            description: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.description", submission: 'Dissertations'),
             path: nil,
             count: nil
           },
           {
             id: 'final-submission-submitted',
-            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.description"),
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.title", submission: 'Dissertations'),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.description", submission: 'Dissertations'),
             path: nil,
             count: nil
           },
@@ -194,8 +194,8 @@ RSpec.describe Admin::SubmissionsDashboardView do
           },
           {
             id: 'released-for-publication',
-            title: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.title"),
-            description: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.description"),
+            title: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.title", submission: 'Dissertations'),
+            description: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.description", submission: 'dissertations'),
             path: nil,
             count: nil
           },
@@ -209,7 +209,7 @@ RSpec.describe Admin::SubmissionsDashboardView do
           },
           {
             id: 'final-withheld',
-            title: I18n.t("#{current_partner.id}.admin_filters.final_withheld.title"),
+            title: I18n.t("#{current_partner.id}.admin_filters.final_withheld.title", submission: 'Dissertations'),
             description: I18n.t("#{current_partner.id}.admin_filters.final_withheld.description"),
             path: nil,
             count: nil,

--- a/spec/presenters/admin/submissions_dashboard_view_spec.rb
+++ b/spec/presenters/admin/submissions_dashboard_view_spec.rb
@@ -29,6 +29,102 @@ RSpec.describe Admin::SubmissionsDashboardView do
   end
 
   describe '#filters' do
+    context 'when viewing masters theses submissions' do
+      #tests language change for thesis vs dissertation in grad school, dissertation is the default & covered by other tests
+      it 'returns a set of placeholders with thesis language' do
+        skip "graduate only" unless current_partner.graduate?
+
+        view = described_class.new('master_thesis')
+        expect(view.filters).to eq [
+          {
+            id: 'format-review-incomplete',
+            title: I18n.t("#{current_partner.id}.admin_filters.format_review_incomplete.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.format_review_incomplete.description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'format-review-submitted',
+            title: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.format_review_submitted.thesis_description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'format-review-completed',
+            title: I18n.t("#{current_partner.id}.admin_filters.format_review_completed.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.format_review_completed.description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-submission-pending',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_pending.thesis_description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'committee-review-rejected',
+            title: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.committee_review_rejected.thesis_description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-submission-submitted',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_submitted.thesis_description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-submission-incomplete',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_incomplete.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_incomplete.description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-submission-approved',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_approved.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_approved.description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-submission-on-hold',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_submission_on_hold.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_submission_on_hold.description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'released-for-publication',
+            title: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.thesis_title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.released_for_publication.thesis_description"),
+            path: nil,
+            count: nil
+          },
+          {
+            id: 'final-restricted-institution',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_restricted_institution.title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_restricted_institution.description"),
+            path: nil,
+            count: nil,
+            sub_count: nil
+          },
+          {
+            id: 'final-withheld',
+            title: I18n.t("#{current_partner.id}.admin_filters.final_withheld.thesis_title"),
+            description: I18n.t("#{current_partner.id}.admin_filters.final_withheld.thesis_description"),
+            path: nil,
+            count: nil,
+            sub_count: nil
+          }
+        ]
+      end
+    end
     context 'when no submissions exist for each filter' do
       it "returns a set of placeholders according to submission status" do
         expect(view.filters).to eq [

--- a/spec/presenters/admin/submissions_dashboard_view_spec.rb
+++ b/spec/presenters/admin/submissions_dashboard_view_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Admin::SubmissionsDashboardView do
 
   describe '#filters' do
     context 'when viewing masters theses submissions' do
-      #tests language change for thesis vs dissertation in grad school, dissertation is the default & covered by other tests
+      # tests language change for thesis vs dissertation in grad school, dissertation is the default & covered by other tests
       it 'returns a set of placeholders with thesis language' do
         skip "graduate only" unless current_partner.graduate?
 
@@ -125,6 +125,7 @@ RSpec.describe Admin::SubmissionsDashboardView do
         ]
       end
     end
+
     context 'when no submissions exist for each filter' do
       it "returns a set of placeholders according to submission status" do
         expect(view.filters).to eq [

--- a/spec/presenters/admin/submissions_index_view_spec.rb
+++ b/spec/presenters/admin/submissions_index_view_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Admin::SubmissionsIndexView do
       let(:scope) { 'released_for_publication' }
 
       it "returns 'Released eTDs'" do
-        expect(view.title).to eq I18n.t("#{current_partner.id}.admin_filters.#{scope}.title")
+        expect(view.title).to eq I18n.t("#{current_partner.id}.admin_filters.#{scope}.title", submission: 'Dissertations')
       end
     end
 
@@ -135,7 +135,7 @@ RSpec.describe Admin::SubmissionsIndexView do
       let(:scope) { 'final_withheld' }
 
       it "returns 'Final Submission is Restricted'" do
-        expect(view.title).to eq I18n.t("#{current_partner.id}.admin_filters.#{scope}.title")
+        expect(view.title).to eq I18n.t("#{current_partner.id}.admin_filters.#{scope}.title", submission: 'Dissertations')
       end
     end
   end


### PR DESCRIPTION
Fixes #764 - adds logic to use the correct language with the correct graduate degree type

`title_for` and `description_for` are used for all filters in each instance, but we only want to change it for the grad school instance for dissertation degree types on the filters that have the word thesis/dissertation. The logic feels a little clunky, but the only alternative I could think if was to add `thesis_description` to the translation for all of the filters which would be redundant/unnecessary for a lot of them. I considered using interpolation, but since capitalization varies by filter (Dissertation vs dissertation), it felt like the logic to handle that wouldn't be an improvement.