### PR TITLE
702 special member names

### DIFF
--- a/app/models/lionpath/lionpath_committee.rb
+++ b/app/models/lionpath/lionpath_committee.rb
@@ -44,13 +44,18 @@ class Lionpath::LionpathCommittee
       hash = {
         committee_role:,
         is_required: true,
-        name: "#{row['First Name']} #{row['Last Name']}",
+        name: special_member?(row) ? "#{row['Special Member First Name']} #{row['Special Member Last Name']}"
+          : "#{row['First Name']} #{row['Last Name']}",
         access_id: row['Access ID'].downcase.to_s,
         is_voting: true,
         lionpath_updated_at: DateTime.now
       }
       hash[:external_to_psu_id] = row['Access ID'].downcase if self.class.external_ids.include?(row['Access ID'].downcase)
       hash
+    end
+
+    def special_member?(row)
+      return row['Special Member First Name'] != nil && row['Special Member Last Name'] != nil
     end
 
     def submission(row)

--- a/app/models/lionpath/lionpath_committee.rb
+++ b/app/models/lionpath/lionpath_committee.rb
@@ -44,8 +44,11 @@ class Lionpath::LionpathCommittee
       hash = {
         committee_role:,
         is_required: true,
-        name: special_member?(row) ? "#{row['Special Member First Name']} #{row['Special Member Last Name']}"
-          : "#{row['First Name']} #{row['Last Name']}",
+        name: if special_member?(row)
+                "#{row['Special Member First Name'].titleize} #{row['Special Member Last Name'].titleize}"
+              else
+                "#{row['First Name']} #{row['Last Name']}"
+              end,
         access_id: row['Access ID'].downcase.to_s,
         is_voting: true,
         lionpath_updated_at: DateTime.now
@@ -55,7 +58,7 @@ class Lionpath::LionpathCommittee
     end
 
     def special_member?(row)
-      return row['Special Member First Name'] != nil && row['Special Member Last Name'] != nil
+      !row['Special Member First Name'].nil? && !row['Special Member Last Name'].nil?
     end
 
     def submission(row)

--- a/app/views/author/committee_members/_committee_member_fields.html.erb
+++ b/app/views/author/committee_members/_committee_member_fields.html.erb
@@ -46,11 +46,8 @@
       </div>
     <% else %>
       <div class="col-sm-6">
-        <% if is_external_member && Lionpath::LionpathCommittee.external_ids.include?(f.object.access_id)%>
-          <%= f.input :name, label: local_presenter.name_label,
-                      aria: { label: "Use arrow keys to navigate your committee member search results to confirm the proper person" },
-                      disabled: disabled_bool, input_html: { class: 'ldap-lookup', value: '' }, required: true %>
-        <% elsif current_partner.graduate? && local_presenter.head_of_program? %>
+        <% if current_partner.graduate? && local_presenter.head_of_program? %>
+          <% # Program chair/head %>
           <%= f.input :name, label: local_presenter.name_label, collection: local_presenter.program_chair_collection,
                       aria: { label: "Use arrow keys to navigate your committee member search results to confirm the proper person" },
                       input_html: { class: 'ldap-lookup', id: 'program-head-name' }, required: true %>

--- a/spec/fixtures/lionpath/lionpath_committee.csv
+++ b/spec/fixtures/lionpath/lionpath_committee.csv
@@ -1,6 +1,6 @@
-Access ID,Last Name,First Name,Role,Committee,Committee Long Descr,Student ID,Student Campus ID,Suprvsr Nbr
+Access ID,Last Name,First Name,Role,Committee,Committee Long Descr,Student ID,Student Campus ID,Suprvsr Nbr,Special Member First Name,Special Member Last Name
 ABC123,Tester1,Test1,CHMJ,DOCCM,Chair & Major Field Represnt,999999999,ABC123,93452345
 ABC456,Tester2,Test2,CMMJ,DOCCM,Committee Member & Major Field Represnt,999999999,ABC123,95423666
 ABC789,Tester3,Test3,CMMJ,DOCCM,Committee Member & Major Field Represnt,999999999,ABC123,94362553
 DEF123,Tester4,Test4,UF,DOCCM,Outside Unit & Field Member,999999999,ABC123,95423565
-DEF456,Tester5,Test5,MD,DOCCM,Major Field Member & Dissertation Advisor,999999999,ABC123,97635463
+DEF456,Tester5,Test5,MD,DOCCM,Major Field Member & Dissertation Advisor,999999999,ABC123,97635463,Vin,Diesel

--- a/spec/integration/author/committee/standard_committee_members_spec.rb
+++ b/spec/integration/author/committee/standard_committee_members_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'The standard committee form for authors', type: :integration, js
     context 'when submission is a master_thesis' do
       it "allows editing and submission of committee", honors: true do
         expect(page).to have_link('Add Committee Member')
-        # visit new_author_submission_committee_members_path(submission)
         submission.required_committee_roles.count.times do |i|
           if i == 0 && current_partner.graduate?
             expect(find("#member-email").readonly?).to eq true
@@ -147,13 +146,13 @@ RSpec.describe 'The standard committee form for authors', type: :integration, js
                                                    access_id: 'mgc25', name: 'Member Committee', email: 'mgc25@psu.edu'
             end
 
-            it 'has an open and blank form for this committee member' do
+            it 'uses the name value for this committee member but keeps it editable' do
               skip 'graduate only' unless current_partner.graduate?
 
               visit edit_author_submission_committee_members_path(submission_2)
               num = submission_2.committee_members.count - 1
               expect(find("#submission_committee_members_attributes_#{num}_name").disabled?).to eq false
-              expect(find("#submission_committee_members_attributes_#{num}_name").value).to eq ''
+              expect(find("#submission_committee_members_attributes_#{num}_name").value).to eq 'Member Committee'
               expect(find("#submission_committee_members_attributes_#{num}_email").readonly?).to eq false
               expect(find("#submission_committee_members_attributes_#{num}_email").value).to eq ''
             end
@@ -233,7 +232,6 @@ RSpec.describe 'The standard committee form for authors', type: :integration, js
     end
 
     it 'allows an additional committee member to be added', js: true do
-      # expect(page).to have_content('successfully')
       expect(page).to have_link('Add Committee Member')
       assert_equal submission.committee_email_list, @email_list.uniq unless current_partner.graduate?
       click_link 'Add Committee Member'

--- a/spec/models/lionpath/lionpath_csv_importer_spec.rb
+++ b/spec/models/lionpath/lionpath_csv_importer_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe Lionpath::LionpathCsvImporter do
         expect(author.submissions.first.committee_members.count).to eq 5
         expect(author.submissions.first.committee_members.first.name).to eq 'Test1 Tester1'
       end
+
       # The last member in the included CSV file has values for 'Special Member {First/Last} Name'
       it 'uses the Special Member fields, when present, to create the name' do
         lionpath_csv_importer.send(:parse_csv, Lionpath::LionpathCommittee.new)
         expect(author.submissions.first.committee_members.last.name).to eq 'Vin Diesel'
       end
     end
-
   end
 end

--- a/spec/models/lionpath/lionpath_csv_importer_spec.rb
+++ b/spec/models/lionpath/lionpath_csv_importer_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe Lionpath::LionpathCsvImporter do
         expect(author.submissions.first.committee_members.count).to eq 5
         expect(author.submissions.first.committee_members.first.name).to eq 'Test1 Tester1'
       end
+      # The last member in the included CSV file has values for 'Special Member {First/Last} Name'
+      it 'uses the Special Member fields, when present, to create the name' do
+        lionpath_csv_importer.send(:parse_csv, Lionpath::LionpathCommittee.new)
+        expect(author.submissions.first.committee_members.last.name).to eq 'Vin Diesel'
+      end
     end
+
   end
 end


### PR DESCRIPTION
closes #702 

When parsing the Lionpath Committee Members CSV, the importer now looks for values present in the Special Members First Name, and Special Members Last Name, and imports and uses them if present.