### PR TITLE
send final reminder when grad submission has 2/3 approval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -279,6 +279,9 @@ Style/NestedParenthesizedCalls:
    - 'spec/models/admin_ability_spec.rb'
    - 'spec/models/author_ability_spec.rb'
 
+Style/OptionalBooleanParameter:
+  Exclude:
+  - 'app/workers/seventh_day_evaluation_worker.rb'
 
 Style/BlockDelimiters:
   Exclude:

--- a/app/mailers/mailer_actions.rb
+++ b/app/mailers/mailer_actions.rb
@@ -15,6 +15,10 @@ module MailerActions
     end
   end
 
+  def send_nonvoting_approval_reminders(submission, committee_member)
+    nonvoting_approval_reminder(submission, committee_member).deliver
+  end
+
   def send_publication_release_messages(submission)
     release_for_publication(submission).deliver if submission.open_access?
     release_for_publication_metadata_only(submission).deliver unless submission.open_access?

--- a/app/mailers/workflow_mailer.rb
+++ b/app/mailers/workflow_mailer.rb
@@ -180,6 +180,17 @@ class WorkflowMailer < ActionMailer::Base
          subject: "#{current_partner.name} #{submission.degree_type} Review Reminder"
   end
 
+  def nonvoting_approval_reminder(submission, committee_member)
+    @submission = submission
+    @committee_member = committee_member
+    @author = submission.author
+    @review_url = "#{EtdUrls.new.workflow}/approver"
+
+    mail to: @committee_member.email,
+         from: current_partner.email_address,
+         subject: "#{current_partner.name} #{submission.degree_type} Final Review Reminder"
+  end
+
   def seventh_day_to_chairs(submission)
     @submission = submission
     @author = submission.author

--- a/app/models/approval_status.rb
+++ b/app/models/approval_status.rb
@@ -84,7 +84,7 @@ class ApprovalStatus
     end
 
     def non_voting_members_present?
-      committee_members.any? {|m| !member_voted?(m) }
+      committee_members.any? { |m| !member_voted?(m) }
     end
 
     def beyond_seven_days?(committee_member)

--- a/app/models/approval_status.rb
+++ b/app/models/approval_status.rb
@@ -35,6 +35,12 @@ class ApprovalStatus
     none || approved || rejected || pending
   end
 
+  def approved_with_non_voters?
+    return false unless approved
+
+    non_voting_members_present?
+  end
+
   private
 
     def none
@@ -75,6 +81,14 @@ class ApprovalStatus
       end
 
       true
+    end
+
+    def non_voting_members_present?
+      non_voting_member = false
+      committee_members.each do |member|
+        non_voting_member = true unless member_voted?(member)
+      end
+      non_voting_member
     end
 
     def beyond_seven_days?(committee_member)

--- a/app/models/approval_status.rb
+++ b/app/models/approval_status.rb
@@ -84,11 +84,7 @@ class ApprovalStatus
     end
 
     def non_voting_members_present?
-      non_voting_member = false
-      committee_members.each do |member|
-        non_voting_member = true unless member_voted?(member)
-      end
-      non_voting_member
+      committee_members.any? {|m| !member_voted?(m) }
     end
 
     def beyond_seven_days?(committee_member)

--- a/app/views/workflow_mailer/nonvoting_approval_reminder.text.erb
+++ b/app/views/workflow_mailer/nonvoting_approval_reminder.text.erb
@@ -1,0 +1,6 @@
+<%= t( "#{current_partner.id}.partner.email.nonvoting_approval_reminder.message",
+       full_name: @author.full_name,
+       title: @submission.title,
+       degree_type: @submission.degree_type,
+       committee_member_name: @committee_member.name,
+       review_url: @review_url) %>

--- a/app/workers/seventh_day_evaluation_worker.rb
+++ b/app/workers/seventh_day_evaluation_worker.rb
@@ -2,17 +2,20 @@ class SeventhDayEvaluationWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'committee_evaluations'
 
-  def perform(submission_id)
+  def perform(submission_id, final_reminder_sent: false)
     submission = Submission.find(submission_id)
     return unless submission.status_behavior.waiting_for_committee_review?
 
-    approval_status = submission.approval_status_behavior.status
-    if approval_status == 'pending'
+    approval = submission.approval_status_behavior
+    if approval.status == 'pending'
       if current_partner.graduate? && submission.degree_type.slug == 'dissertation'
         dissertation_emails(submission)
       else
         non_dissertation_emails(submission)
       end
+    elsif approval.approved_with_non_voters? && current_partner.graduate? && final_reminder == false
+      approval_reminder_emails(submission)
+      SeventhDayEvaluationWorker.perform_in(7.days, submission_id, final_reminder_sent: true)
     else
       SubmissionStatusUpdaterService.new(submission).update_status_from_committee
     end
@@ -28,6 +31,12 @@ class SeventhDayEvaluationWorker
     def non_dissertation_emails(submission)
       submission.voting_committee_members.each do |cm|
         WorkflowMailer.send_committee_review_reminders(submission, cm) if %w[approved rejected].exclude? cm.status
+      end
+    end
+
+    def approval_reminder_emails(submission)
+      submission.voting_committee_members.each do |cm|
+        WorkflowMailer.send_nonvoting_approval_reminders(submission, cm) if %w[approved rejected].exclude? cm.status
       end
     end
 end

--- a/app/workers/seventh_day_evaluation_worker.rb
+++ b/app/workers/seventh_day_evaluation_worker.rb
@@ -2,7 +2,7 @@ class SeventhDayEvaluationWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'committee_evaluations'
 
-  def perform(submission_id, final_reminder_sent: false)
+  def perform(submission_id, final_reminder_sent = false)
     submission = Submission.find(submission_id)
     return unless submission.status_behavior.waiting_for_committee_review?
 
@@ -13,9 +13,9 @@ class SeventhDayEvaluationWorker
       else
         non_dissertation_emails(submission)
       end
-    elsif approval.approved_with_non_voters? && current_partner.graduate? && final_reminder == false
+    elsif approval.approved_with_non_voters? && current_partner.graduate? && final_reminder_sent == false
       approval_reminder_emails(submission)
-      SeventhDayEvaluationWorker.perform_in(7.days, submission_id, final_reminder_sent: true)
+      SeventhDayEvaluationWorker.perform_in(7.days, submission_id, true)
     else
       SubmissionStatusUpdaterService.new(submission).update_status_from_committee
     end

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -156,6 +156,16 @@ en:
                     115 Kern Building
                     Graduate School
                     University Park, PA  16802
+        nonvoting_approval_reminder:
+          message: |
+                    Dear %{committee_member_name},              
+                    This will be your final opportunity to vote on %{full_name}'s final work. If you do not vote 
+                    within seven days, your name will be removed from the student’s work.
+
+                    %{review_url}
+        
+                    Thank You,
+                    Office of Theses and Dissertations
         seventh_day_to_chairs:
           message: |
                     The committee for %{author_name}'s %{degree_type} has not completed its review after 7 days.

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -587,6 +587,27 @@ RSpec.describe WorkflowMailer do
     end
   end
 
+  describe '#nonvoting_approval_reminder' do
+    let(:email) { described_class.nonvoting_approval_reminder(submission, committee_member) }
+
+    it "is sent to the proper recipient" do
+      expect(email.to).to eq([committee_member.email])
+    end
+
+    it "is sent from the partner support email address" do
+      expect(email.from).to eq([partner_email])
+    end
+
+    it "sets an appropriate subject" do
+      expect(email.subject).to eq("#{current_partner.name} #{submission.degree_type} Final Review Reminder")
+    end
+
+    it "has desired content" do
+      expect(email.body).to match(/\/approver/)
+      expect(email.body).to match(/final opportunity to vote/)
+    end
+  end
+
   describe '#advisor_rejected' do
     let(:email) { described_class.advisor_rejected(submission) }
 

--- a/spec/models/approval_status_spec.rb
+++ b/spec/models/approval_status_spec.rb
@@ -529,6 +529,90 @@ RSpec.describe ApprovalStatus, type: :model do
     end
   end
 
+  describe "#approved_with_non_voters?" do
+    before do
+      submission.degree.degree_type.approval_configuration = approval_configuration4
+    end
+
+    context 'when not approved' do
+      it "returns false" do
+        submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                          submission:,
+                                                          status: 'approved',
+                                                          is_voting: true,
+                                                          approval_started_at: (DateTime.now - (7.days + 1.hour)))
+        submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                          submission:,
+                                                          status: 'rejected',
+                                                          is_voting: true,
+                                                          approval_started_at: (DateTime.now - (7.days + 1.hour)))
+        submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                          submission:,
+                                                          status: 'rejected',
+                                                          is_voting: true,
+                                                          approval_started_at: (DateTime.now - (7.days + 1.hour)))
+
+        expect(described_class.new(submission).approved_with_non_voters?).to eq(false)
+      end
+    end
+
+    context 'when approved' do
+      context 'when there are members who have not voted' do
+        it "returns true" do
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: '',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+
+          expect(described_class.new(submission).approved_with_non_voters?).to eq(true)
+        end
+      end
+
+      context 'when all members have voted' do
+        it "returns false" do
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                            submission:,
+                                                            status: 'approved',
+                                                            is_voting: true,
+                                                            approval_started_at: (DateTime.now - (7.days + 1.hour)))
+
+          expect(described_class.new(submission).approved_with_non_voters?).to eq(false)
+        end
+      end
+    end
+  end
+
   describe "#head_of_program_status" do
     before do
       head_role = CommitteeRole.find_by(is_program_head: true, degree_type_id: submission.degree.degree_type_id)

--- a/spec/workers/seventh_day_evaluation_worker_spec.rb
+++ b/spec/workers/seventh_day_evaluation_worker_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe SeventhDayEvaluationWorker do
   let!(:degree1) { FactoryBot.create :degree, degree_type: DegreeType.default }
   let!(:degree2) { FactoryBot.create :degree, degree_type: DegreeType.last }
   let!(:submission) { FactoryBot.create :submission, :waiting_for_committee_review, degree: degree1 }
+  let!(:approval_configuration) do
+    ApprovalConfiguration.create(configuration_threshold: 66,
+                                 use_percentage: 1,
+                                 approval_deadline_on: Time.zone.today,
+                                 head_of_program_is_approving: false)
+  end
+
+  before do
+    submission.degree.degree_type.approval_configuration = approval_configuration
+  end
 
   it 'queues to sidekiq via worker' do
     expect { described_class.perform_in(7.days, submission.id) }.to change { Sidekiq::Worker.jobs.size }.by(1)
@@ -68,11 +78,79 @@ RSpec.describe SeventhDayEvaluationWorker do
         end
       end
 
-      context "when submission approval status is not 'pending'" do
+      context "when submission approval status is 'approved'" do
+        before do
+          allow_any_instance_of(Submission).to receive(:head_of_program_is_approving?).and_return false
+          allow(described_class).to receive(:perform_in).with(7.days, submission.id, final_reminder_sent: true)
+        end
+
+        context "when graduate and there are nonvoting members" do
+          before do
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: '',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          end
+
+          it 'sends final reminder emails' do
+            skip "graduate only" unless current_partner.graduate?
+
+            Sidekiq::Testing.inline! do
+              expect { described_class.perform_async(submission.id) }.to change { WorkflowMailer.deliveries.size }.by(1)
+              expect(described_class).to have_received(:perform_in).with(7.days, submission.id, final_reminder_sent: true)
+            end
+            expect(WorkflowMailer.deliveries.first.subject).to match(/Final Review Reminder/)
+          end
+        end
+
+        context "when all members have voted" do
+          before do
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+            submission.committee_members << FactoryBot.create(:committee_member, :review_started,
+                                                              submission:,
+                                                              status: 'approved',
+                                                              is_voting: true,
+                                                              approval_started_at: (DateTime.now - (7.days + 1.hour)))
+          end
+
+          it 'runs submission status update from committee' do
+            expect_any_instance_of(SubmissionStatusUpdaterService).to receive(:update_status_from_committee)
+            Sidekiq::Testing.inline! do
+              described_class.perform_async(submission.id)
+            end
+          end
+        end
+      end
+
+      context "when submission status is 'rejected'" do
         before do
           create_committee submission
-          allow_any_instance_of(ApprovalStatus).to receive(:status).and_return 'approved'
-          allow_any_instance_of(Submission).to receive(:head_of_program_is_approving?).and_return false
+          allow_any_instance_of(ApprovalStatus).to receive(:status).and_return 'rejected'
         end
 
         it 'runs submission status update from committee' do


### PR DESCRIPTION
Fixes #762 

If a graduate submission has 2/3 approval by the day seven evaluation and has committee members who have not voted, nonvoting members are sent a final reminder email and the evaluation worker is set to run in another 7 days. At that point (day 14), the submission is moved forward and any remaining nonvoting members are marked as did not vote. OTD will handle notifying the student and removing nonvoting members.