### PR TITLE
Matching Grad School degrees to import LP degrees

### DIFF
--- a/app/models/lionpath/lionpath_program.rb
+++ b/app/models/lionpath/lionpath_program.rb
@@ -83,8 +83,8 @@ class Lionpath::LionpathProgram
     end
 
     def degree(row)
-      incoming_dg = row['Degree'].to_s.upcase
-      Degree.find_by(name: incoming_dg)
+      incoming_dg = row['Degree'].to_s.upcase.gsub('_', ' ')
+      Degree.where('upper(name) = ?', incoming_dg).first
     end
 
     def sp2021_subs(author)

--- a/spec/models/lionpath/lionpath_program_spec.rb
+++ b/spec/models/lionpath/lionpath_program_spec.rb
@@ -89,9 +89,8 @@ RSpec.describe Lionpath::LionpathProgram do
       expect(Submission.first.author).to eq author
     end
 
-
     context 'when Degree in LP data is "M_ED"' do
-      before do 
+      before do
         lionpath_program.import(row_4)
       end
 

--- a/spec/models/lionpath/lionpath_program_spec.rb
+++ b/spec/models/lionpath/lionpath_program_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Lionpath::LionpathProgram do
 
   let!(:degree) { FactoryBot.create :degree, name: 'PHD' }
   let!(:degree_ms) { FactoryBot.create :degree, name: 'MS' }
+  let!(:degree_m_ed) { FactoryBot.create :degree, name: 'M Ed' }
 
   let(:row_1) do
     {
@@ -36,6 +37,16 @@ RSpec.describe Lionpath::LionpathProgram do
     }
   end
 
+  let(:row_4) do
+    {
+      'ID' => 999999999, 'Last Name' => 'Tester', 'First Name' => 'Test', 'Campus ID' => 'xxb13', 'Exp Grad' => 2215,
+      'Acadademic Plan' => 'CNED_M_ED', 'Degree' => 'M_ED', 'Transcript Descr' => 'Master of Education',
+      'Milestone Code' => nil, 'Milestone Desc' => nil, 'Date Attempted' => nil, 'Exam Status' => nil,
+      'Alternate Email' => 'test@psu.edu', 'Campus' => 'UP', 'Acad Prog' => 'GREN', 'ChkoutStat' => 'EG',
+      'Can Nbr' => 114
+    }
+  end
+
   context 'when no author or program exists' do
     before do
       lionpath_program.import(row_1)
@@ -57,7 +68,7 @@ RSpec.describe Lionpath::LionpathProgram do
       expect(Author.first.submissions.first.program.is_active).to eq(true)
       expect(Author.first.submissions.first.program.lionpath_updated_at).to be_truthy
       expect(Author.first.submissions.first.lionpath_updated_at).to be_truthy
-      expect(Author.first.submissions.first.degree.name).to eq(row_1['Acadademic Plan'].split('_')[1].to_s)
+      expect(Author.first.submissions.first.degree.name).to eq('PHD')
       expect(Author.first.submissions.first.lionpath_year).to eq(2021)
       expect(Author.first.submissions.first.lionpath_semester).to eq('Summer')
       expect(Author.first.submissions.first.campus).to eq('UP')
@@ -76,6 +87,17 @@ RSpec.describe Lionpath::LionpathProgram do
       expect { lionpath_program.import(row_1) }.to change(Author, :count).by 0
       expect(Submission.first.program).to eq program
       expect(Submission.first.author).to eq author
+    end
+
+
+    context 'when Degree in LP data is "M_ED"' do
+      before do 
+        lionpath_program.import(row_4)
+      end
+
+      it 'matches "M Ed" in the database by stripping underscores and matching when uppercase' do
+        expect(Author.first.submissions.first.degree.name).to eq('M Ed')
+      end
     end
   end
 


### PR DESCRIPTION
Match imported program data to degree in our database by replacing underscores with spaces and matching both values when uppercase