### PR TITLE
802 - Adds help text for approvers

### DIFF
--- a/app/views/approver/index.html.erb
+++ b/app/views/approver/index.html.erb
@@ -4,6 +4,9 @@
       <h1>My Reviews</h1>
       <p>The following table contains a list of your reviews.  To begin reviewing a submission, click the title of the submission below.  If you are serving on a committee as multiple roles, you will only need to submit your review once for that submission. To see your completed reviews, select "Finished Reviews" from the dropdown filter below.</p>
       <p>If you are not sure what to do, click the following link for a <a href='/docs'>walkthrough</a>.</p>
+      <% if current_partner.graduate? %>
+        <p><%= I18n.t("graduate.approval_help.message").html_safe %></p>
+      <% end %>
     </div>
   </div>
   <br>

--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -25,4 +25,7 @@
       <br>
       <img class="docs-image" src="/docs_images/sd-3.png" alt="submission approval image" height="500" width="1350">
     </ol>
+    <% if current_partner.graduate? %>
+    <p><%= I18n.t("graduate.approval_help.message").html_safe %></p>
+  <% end %>
 </div>

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -118,6 +118,9 @@ en:
                     Please login to %{review_url} and complete this request.
                     If you are serving on this committee in multiple roles, you will only need to submit your review once.
                     %{core_member_note}
+
+                    If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at gradthesis@psu.edu so that we may proxy for you.
+
                     If you have any further questions please contact gradthesis@psu.edu.
                     Sincerely,
                     The Graduate School
@@ -423,6 +426,8 @@ en:
         scope: final_withheld
     download:
       login_html: 'Login using your Penn State access account to view the paper.'
+    approval_help:
+      message: "If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at <a href='mailto:gradthesis@psu.edu' target='_blank'>gradthesis@psu.edu</a> so that we may proxy for you."
     fee_message:
       master_thesis:
         message: "Before proceeding to your final submission, you must pay the $10 thesis fee.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>."


### PR DESCRIPTION
Closes #802 

Provides troubleshooting advice and contact information to approvers who are stuck on the approver and docs pages, as well as in the email.