### PR TITLE
Fee Payment handle spaces in degree name

### DIFF
--- a/app/services/fee_payment_service.rb
+++ b/app/services/fee_payment_service.rb
@@ -41,7 +41,8 @@ class FeePaymentService
     end
 
     def degree_name
-      submission.degree.name
+      # All caps and convert space to underscore to match GPMS pattern
+      submission.degree.name.upcase.gsub(' ', '_')
     end
 
     attr_accessor :submission

--- a/spec/services/fee_payment_service_spec.rb
+++ b/spec/services/fee_payment_service_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe FeePaymentService do
         expect(service.fee_is_paid?).to eq true
       end
     end
+
+    context "when the submission degree is M Ed" do
+      it 'returns true' do
+        submission.degree.name = 'M Ed'
+        submission.save!
+        stub_request(:get, "https://secure.gradsch.psu.edu/services/etd/etdPayment.cfm?degree=M_ED&psuid=#{submission.author.psu_idn}")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: "\r\n    {\"data\":[{\"ETDPAYMENTFOUND\":\"Y\"}],\"error\":\"\"}\r\n    ", headers: {})
+        expect(service.fee_is_paid?).to eq true
+      end
+    end
   end
 
   context "when the student's fee has not been paid" do


### PR DESCRIPTION
Convert degree name to match GPMS pattern when checking to see if fee is paid.  Adds test for this.

A little context:  The user we are allowing to submit with a Master's in Education is not able to get past the fee payment stage because we don't handle spaces in the degree name when making this request to GPMS.