### PR TITLE
796 format accepted mailers grad

### DIFF
--- a/app/mailers/workflow_mailer.rb
+++ b/app/mailers/workflow_mailer.rb
@@ -1,10 +1,21 @@
+# frozen_string_literal: true
+
 class WorkflowMailer < ActionMailer::Base
   class InvalidPartner < StandardError; end
   extend MailerActions
 
+  APPROVER_WORKFLOW = "#{EtdUrls.new.workflow}/approver".freeze
+  AUTHOR_WORKFLOW = "#{EtdUrls.new.workflow}/author".freeze
+  COMMENCEMENT_URL = I18n.t("#{current_partner.id}.partner.commencement_url")
+  DEADLINE_URL = I18n.t("#{current_partner.id}.partner.deadline_url")
+  EXPLORE_SITE = EtdUrls.new.explore.to_s
+  PAYMENT_PORTAL_URL = I18n.t("#{current_partner.id}.partner.payment_portal_url")
+  THESIS_GUIDE = I18n.t("#{current_partner.id}.partner.thesis_guide_pdf")
+
   def format_review_received(submission)
     @submission = submission
     @author = submission.author
+    @payment_portal_url = PAYMENT_PORTAL_URL
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -16,6 +27,9 @@ class WorkflowMailer < ActionMailer::Base
 
     @submission = submission
     @author = submission.author
+    @deadline_url = DEADLINE_URL
+    @etd_site = AUTHOR_WORKFLOW
+    @thesis_guide = THESIS_GUIDE
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -27,6 +41,9 @@ class WorkflowMailer < ActionMailer::Base
 
     @submission = submission
     @author = submission.author
+    @deadline_link = DEADLINE_URL
+    @etd_site = AUTHOR_WORKFLOW
+    @thesis_guide = THESIS_GUIDE
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -45,7 +62,9 @@ class WorkflowMailer < ActionMailer::Base
   def final_submission_approved(submission)
     @submission = submission
     @author = submission.author
-    @url = EtdUrls.new.explore.to_s
+    @commencement_url = COMMENCEMENT_URL
+    @etd_site = AUTHOR_WORKFLOW
+    @explore_site = EXPLORE_SITE
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -55,7 +74,9 @@ class WorkflowMailer < ActionMailer::Base
   def final_submission_rejected(submission)
     @submission = submission
     @author = submission.author
-    @url = "#{EtdUrls.new.workflow}/author"
+    @etd_site = AUTHOR_WORKFLOW
+    @thesis_guide = THESIS_GUIDE
+    @deadline_url = DEADLINE_URL
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -65,7 +86,7 @@ class WorkflowMailer < ActionMailer::Base
   def release_for_publication(submission)
     @submission = submission
     @author = submission.author
-    @explore_url = "#{EtdUrls.new.explore}/catalog/#{submission.public_id}"
+    @explore_url = EXPLORE_SITE
 
     mail to: [@author.psu_email_address, @author.alternate_email_address],
          from: current_partner.email_address,
@@ -75,7 +96,7 @@ class WorkflowMailer < ActionMailer::Base
   def release_for_publication_metadata_only(submission)
     @submission = submission
     @author = submission.author
-    @explore_url = "#{EtdUrls.new.explore}/catalog/#{submission.public_id}"
+    @explore_url = EXPLORE_SITE
 
     mail to: [@author.psu_email_address, @author.alternate_email_address],
          from: current_partner.email_address,
@@ -126,7 +147,7 @@ class WorkflowMailer < ActionMailer::Base
     @submission = submission
     @committee_member = committee_member
     @author = submission.author
-    @review_url = "#{EtdUrls.new.workflow}/approver"
+    @review_url = APPROVER_WORKFLOW
 
     @committee_member.update approval_started_at: DateTime.now if @committee_member.approval_started_at.blank?
     @committee_member.update_last_reminder_at DateTime.now
@@ -159,7 +180,7 @@ class WorkflowMailer < ActionMailer::Base
     @submission = submission
     @committee_member = committee_member
     @author = submission.author
-    @review_url = "#{EtdUrls.new.workflow}/approver"
+    @review_url = APPROVER_WORKFLOW
 
     @committee_member.update approval_started_at: DateTime.now if @committee_member.approval_started_at.blank?
     @committee_member.update_last_reminder_at DateTime.now
@@ -170,10 +191,12 @@ class WorkflowMailer < ActionMailer::Base
   end
 
   def nonvoting_approval_reminder(submission, committee_member)
+    raise InvalidPartner unless current_partner.graduate?
+
     @submission = submission
     @committee_member = committee_member
     @author = submission.author
-    @review_url = "#{EtdUrls.new.workflow}/approver"
+    @review_url = APPROVER_WORKFLOW
 
     mail to: @committee_member.email,
          from: current_partner.email_address,
@@ -230,6 +253,7 @@ class WorkflowMailer < ActionMailer::Base
   def pending_returned_author(submission)
     @submission = submission
     @author = submission.author
+    @etd_site = AUTHOR_WORKFLOW
 
     mail to: @author.psu_email_address,
          from: current_partner.email_address,
@@ -254,6 +278,7 @@ class WorkflowMailer < ActionMailer::Base
     @submission = submission
     @author = submission.author
     @review_results = ReviewResultsEmail.new(submission).generate
+    @etd_site = AUTHOR_WORKFLOW
     to = if current_partner.graduate?
            [@author.psu_email_address, submission.advisor&.email, submission.chairs&.pluck(:email)].flatten.uniq.compact
          else
@@ -296,7 +321,7 @@ class WorkflowMailer < ActionMailer::Base
   def committee_approved(submission)
     @submission = submission
     @author = submission.author
-    @explore_url = EtdUrls.new.explore.to_s
+    @explore_url = EXPLORE_SITE
 
     mail to: @author.psu_email_address,
          cc: [@submission.committee_email_list.uniq, current_partner.email_address].flatten,

--- a/app/mailers/workflow_mailer.rb
+++ b/app/mailers/workflow_mailer.rb
@@ -12,7 +12,7 @@ class WorkflowMailer < ActionMailer::Base
   end
 
   def format_review_accepted(submission)
-    raise InvalidPartner unless current_partner.sset? || current_partner.honors?
+    raise InvalidPartner unless current_partner.sset? || current_partner.honors? || current_partner.graduate?
 
     @submission = submission
     @author = submission.author
@@ -23,7 +23,7 @@ class WorkflowMailer < ActionMailer::Base
   end
 
   def format_review_rejected(submission)
-    raise InvalidPartner unless current_partner.sset? || current_partner.honors?
+    raise InvalidPartner unless current_partner.sset? || current_partner.honors? || current_partner.graduate?
 
     @submission = submission
     @author = submission.author

--- a/app/services/format_review_update_service.rb
+++ b/app/services/format_review_update_service.rb
@@ -25,7 +25,7 @@ class FormatReviewUpdateService
       UpdateSubmissionService.admin_update_submission(submission, current_remote_user, format_review_params)
       submission.update! format_review_approved_at: Time.zone.now
       status_giver.collecting_final_submission_files!
-      WorkflowMailer.format_review_accepted(@submission).deliver if current_partner.sset? || current_partner.honors?
+      WorkflowMailer.format_review_accepted(@submission).deliver if current_partner.sset? || current_partner.honors? || current_partner.graduate?
       msg = "The submission\'s format review information was successfully approved and returned to the author to collect final submission information."
     elsif update_actions.rejected?
       UpdateSubmissionService.admin_update_submission(submission, current_remote_user, format_review_params)

--- a/app/services/format_review_update_service.rb
+++ b/app/services/format_review_update_service.rb
@@ -25,13 +25,13 @@ class FormatReviewUpdateService
       UpdateSubmissionService.admin_update_submission(submission, current_remote_user, format_review_params)
       submission.update! format_review_approved_at: Time.zone.now
       status_giver.collecting_final_submission_files!
-      WorkflowMailer.format_review_accepted(@submission).deliver if current_partner.sset? || current_partner.honors? || current_partner.graduate?
+      WorkflowMailer.format_review_accepted(@submission).deliver unless current_partner.milsch?
       msg = "The submission\'s format review information was successfully approved and returned to the author to collect final submission information."
     elsif update_actions.rejected?
       UpdateSubmissionService.admin_update_submission(submission, current_remote_user, format_review_params)
       submission.update! format_review_rejected_at: Time.zone.now
       status_giver.collecting_format_review_files_rejected!
-      WorkflowMailer.format_review_rejected(@submission).deliver if current_partner.sset? || current_partner.honors?
+      WorkflowMailer.format_review_rejected(@submission).deliver unless current_partner.milsch?
       msg = "The submission\'s format review information was successfully rejected and returned to the author for revision."
     end
     if update_actions.record_updated?

--- a/app/views/workflow_mailer/committee_rejected_author.text.erb
+++ b/app/views/workflow_mailer/committee_rejected_author.text.erb
@@ -5,4 +5,4 @@ Dear <%= @submission.author.full_name %>,
        partner_name: current_partner.name,
        author_name: @author.full_name,
        review_results: @review_results,
-       url: @url,) %>
+       etd_site: @etd_site) %>

--- a/app/views/workflow_mailer/final_submission_approved.text.erb
+++ b/app/views/workflow_mailer/final_submission_approved.text.erb
@@ -5,5 +5,7 @@ Dear <%= @author.full_name %>,
        degree_type: @submission.degree_type,
        partner_name: current_partner.name,
        author_email: @author.psu_email_address,
-       url: @url,
+       etd_site: @etd_site,
+       explore_site: @explore_site,
+       commencement_url: @commencement_url,
        committee_email_list: @submission.committee_email_list.join(", ") ) %>

--- a/app/views/workflow_mailer/final_submission_rejected.text.erb
+++ b/app/views/workflow_mailer/final_submission_rejected.text.erb
@@ -5,5 +5,7 @@ Dear <%= @author.full_name %>,
        degree_type: @submission.degree_type,
        partner_name: current_partner.name,
        author_email: @author.psu_email_address,
-       url: @url,
+       etd_site: @etd_site,
+       thesis_guide: @thesis_guide,
+       deadline_url: @deadline_url,
        committee_email_list: @submission.committee_email_list.join(", ") ) %>

--- a/app/views/workflow_mailer/format_review_accepted.text.erb
+++ b/app/views/workflow_mailer/format_review_accepted.text.erb
@@ -1,3 +1,4 @@
 Dear <%= @author.full_name %>,
 
-<%= t( "#{current_partner.id}.partner.email.format_review_accepted.message", degree_type: @submission.degree_type) %>
+<%= t( "#{current_partner.id}.partner.email.format_review_accepted.message", degree_type: @submission.degree_type,
+deadline_url: @deadline_url, etd_site: @etd_site, thesis_guide: @thesis_guide) %>

--- a/app/views/workflow_mailer/format_review_received.text.erb
+++ b/app/views/workflow_mailer/format_review_received.text.erb
@@ -1,5 +1,4 @@
 Dear <%= @author.full_name %>,
 
 <%= t( "#{current_partner.id}.partner.email.format_review_received.message",
-       degree_type: @submission.degree_type) %>
-
+       degree_type: @submission.degree_type, payment_portal_url: @payment_portal_url) %>

--- a/app/views/workflow_mailer/format_review_rejected.text.erb
+++ b/app/views/workflow_mailer/format_review_rejected.text.erb
@@ -1,3 +1,4 @@
 Dear <%= @author.full_name %>,
 
-<%= t( "#{current_partner.id}.partner.email.format_review_rejected.message", degree_type: @submission.degree_type, url: @url,) %>
+<%= t( "#{current_partner.id}.partner.email.format_review_rejected.message",
+deadline_url: @deadline_url, etd_site: @etd_site, thesis_guide: @thesis_guide,) %>

--- a/app/views/workflow_mailer/pending_returned_author.text.erb
+++ b/app/views/workflow_mailer/pending_returned_author.text.erb
@@ -1,3 +1,4 @@
 Dear <%= @author.full_name %>,
 
-<%= t( "#{current_partner.id}.partner.email.pending_returned_author.message", degree_type: @submission.degree_type) %>
+<%= t( "#{current_partner.id}.partner.email.pending_returned_author.message", degree_type: @submission.degree_type,
+etd_site: @etd_site ) %>

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -33,8 +33,12 @@ en:
         text: <p>The primary purpose of a thesis or dissertation is to train the student in the process of scholarly research and writing under the direction of members of the Graduate Faculty. After the student has graduated and the work is published, it serves as a contribution to human knowledge, is useful to other scholars and perhaps even to a more general audience. Electronic thesis and dissertations (eTDs) expand the creative possibilities open to students and empower students to convey a richer message by permitting video, sound, and color images to be integrated into their work. Submitting and archiving eTDs helps students to understand electronic publishing issues and provides greater acess to students' research. Through the Web, people from any place on the globe can link directly to eTD collections at Penn State and other universities.</p><p>The Graduate School, the University Libraries, and the Graduate Faculty of Penn State have established format standards that theses and dissertations must meet before receiving final approval as fulfillment of graduate requirements.  The Office of Theses and Dissertations staff is responsible for verifying that all eTDs have met these requirements <a href="%{thesis_guide_link}">(refer to the Thesis and Dissertation Guide)</a>.  The text of the eTD should be proofread and free of grammatical errors and typos.  It is extremely important that the author carefully review and proofread the thesis or dissertation before submitting the final document.  After the official approval of the final eTD by the Office of Theses and Dissertations, changes will not be permitted.</p>
       alternate_email_hint: 'The Alternate email address will be used after your psu.edu email address expires.'
       semester_hint: Only upload your dissertation or thesis if you intend to graduate this semester or the following semester.
-      thesis_guide: 'https://gradschool.psu.edu/academics/theses-and-dissertations#Handbook-138642'
+      thesis_guide: 'http://www.gradschool.psu.edu/index.cfm/current-students/etd/'
+      thesis_guide_pdf: 'https://gradschool.psu.edu/assets/uploads/documents/Thesis-and-Dissertation-Handbook.pdf'
+      payment_portal_url: 'https://secure.gradsch.psu.edu/paymentportal/'
+      commencement_url: 'https://gradschool.psu.edu/academics/commencement'
       document_title_label: 'Please enter your Thesis or Dissertation Title'
+      deadline_url: 'https://gradschool.psu.edu/academics/academic-dates-and-deadlines'
       url_slug: 'etda'
       lionpath_alert: More than 10% of LionPATH %{resource} were tagged for deletion at %{datetime_now}.  The deletion process was not completed because of this.  This could indicate that there was an issue with the LionPATH import or one of the CSVs used during the import.
       not_allowed_alert: You are not allowed to visit that page at this time, please contact your administrator at gradthesis@psu.edu
@@ -45,159 +49,121 @@ en:
         signature: 'Graduate School <br />Keller Building<br /> University Park, PA'
         final_submission_rejected:
           message: |
-                    Your final %{degree_type} has been rejected by the Office of Theses and Dissertations.
-                    You will need to make the necessary revisions or corrections to your document and resubmit your %{degree_type}.
+                    Your final submission has been rejected by the Office of Theses and Dissertations. To see the necessary revisions, please review the notes on the <a href="%{etd_site}" target="_blank">ETD</a>. <em>The next step is to make the necessary revisions or corrections to your document and then, resubmit an updated final submission to the ETD.</em>
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Please refer to the <a href="%{thesis_guide}" target="_blank">Thesis and Dissertation Handbook</a> while making corrections. <em>Not uploading your revised final submission by the <a href="%{deadline_url}" target="_blank">deadline</a> will result in you being removed from the graduation list.</em>
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         final_submission_approved:
           message: |
-                    Congratulations! Your final %{degree_type} has been approved by the Office of Theses and Dissertations.
+                    Congratulations! Your final submission has been approved by the Office of Theses and Dissertations. After graduation, your work will be available through Penn State's <a href="%{explore_site}" target="_blank">ETD database</a> and will be sent to ProQuest/UMI Dissertation Services for processing <em>unless you have chosen to restrict access to it.</em>
 
-                    After graduation, the eTD will be available through Penn State’s eTD database %{url} and will be sent
-                    to ProQuest/UMI Dissertation Services for processing unless you have chosen to restrict access to it.
-                    If it is restricted, it will automatically change to Open Access after two years.
-                    The access level for your %{degree_type} is: %{access_level}.
-                    Please accept our congratulations as you complete your degree.
-                    (commencement information can be found online as http://commencement.psu.edu/).
+                    If you have chosen “Penn State Restricted” or “Full Restricted” embargo statuses, it will automatically change to “Open Access” after two years. The access level for your %{degree_type} is: %{access_level}. Please accept our congratulations as you complete your degree. Commencement information can be found on the <a href="%{commencement_url}" target="_blank">Graduate School Commencement Page.</a>
 
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         final_submission_received:
           message: |
-                    Thank you for submitting your final %{degree_type}.  It will now be automatically sent to your committee for review and approval.
-                    No action is required of you at this time.
-                    You will be notified once your committee has reviewed and made a decision regarding your document.
+                    Thank you for submitting your final submission. Your final submission has been automatically sent through the ETD system to your committee members' emails for approval. 
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    <em>Students are required to ensure that each of their committee members approve.</em> You will be notified once your committee has reviewed and made a decision regarding your document. Please ensure that your embargo status is correct and remember that no changes can be made after this point.
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         format_review_rejected:
           message: |
-                    To be determined.
+                    Your format review has been rejected by the Office of Theses and Dissertations. To see the necessary revisions, please review the notes on the <a href="%{etd_site}" target="_blank">ETD</a>. <em>The next step is to make the necessary revisions or corrections to your document and then, resubmit an updated format review to the ETD.</em>
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Please refer to the <a href="%{thesis_guide}" target="_blank">Thesis and Dissertation Handbook</a> while making corrections. Not uploading your revised format review by the <a href="%{deadline_url}" target="_blank">deadline</a> will result in you being removed from the graduation list. 
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814)865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         format_review_accepted:
           message: |
-                    To be determined.
+                    Your format review has been approved, but revisions might be needed before you submit the final version of your work. To see if you have any necessary revisions, please review the notes and files on the <a href="%{etd_site}" target="_blank">ETD.</a> There, you will find your format review with corrections listed in the comments. Comments can be viewed by opening the PDF in Adobe Acrobat. 
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
-                    Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802       
+                    <em>The next step is to prepare your final submission and review this with each of your committee members. Once this review is completed and all final revisions have been made, upload your final submission to the ETD, where your committee members will electronically approve your final submission. Not uploading your final submission by the <a href="%{deadline_url}" target="_blank">deadline</a> will result in you being removed from the graduation list.</em>
+
+                    Please refer to the <a href="%{thesis_guide}" target="_blank">Thesis and Dissertation Handbook</a> when making corrections. Please keep in mind the <a href="%{deadline_url}" target="_blank">deadline</a> for the final submission of your dissertation. Please note that the final submission is mandatory, and submitting it late may affect your ability to graduate on time.
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
+                    Office of Theses and Dissertations    
         format_review_received:
           message: |
-                    Thank you for submitting your %{degree_type} for format review. Our staff will be in touch with
-                    you when the review has been completed.
-                    You will receive the results of the review by email within 2-3 weeks.
+                    Thank you for submitting your %{degree_type} format review. Our staff will be in touch with you when the review has been completed. If you are graduating this semester, you will receive the results of the review by email within 2-3 weeks. If you have not already done so, you must pay your thesis fee at the <a href="%{payment_portal_url}" target="_blank">Graduate School Payment Portal.</a> You only need to pay once. 
 
-                    If you have not already done so, you must pay your thesis fee here: https://secure.gradsch.psu.edu/paymentportal/
-                    You only need to pay once.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call (814)865-1795.
 
-                    Please be aware that the order of the approval process for the final %{degree_type} has been revised.
-                    The committee members will now approve the %{degree_type} prior to the Office of Theses and Dissertations.
-                    The review and approval of the final submission by each committee member should be completed
-                    before the final %{degree_type} is uploaded to the eTD site.
-                    Following the approval of the committee members, the final document will be reviewed and
-                    approved by The Office of Theses and Dissertations.
+                    Best,
 
-                    Please refer to the deadline calendar on the graduate school website under “Thesis and Dissertation Information”, for all deadlines.
-
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         sent_to_committee:
           message: |
-                    Your %{degree_type}: "%{title}" has been sent back to the committee review stage to be approved by your committee.
-                    No action is required of you at this time.
-                    You will be notified once your committee has reviewed and made a decision regarding your document.
+                    Your %{degree_type}: "%{title}" has been sent back to the committee review stage to be approved by your committee. <em>Students are required to ensure that each of their committee members approves.</em> You will be notified once your committee has reviewed and made a decision regarding your document.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         committee_member_review_requested:
           message: |
                     Hello %{committee_member_name},
 
-                    The Graduate School and %{full_name} require you to review and digitally sign a proposed work for which you have been
-                    listed as a committee member.
-                    Please login to %{review_url} and complete this request.
-                    If you are serving on this committee in multiple roles, you will only need to submit your review once.
-                    %{core_member_note}
+                    The Graduate School and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. Please login to %{review_url} and complete this request. If you are serving on this committee as either the program head or the professor in charge/director of graduate studies, you might be requested to approve the work twice. 
 
-                    If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at gradthesis@psu.edu so that we may proxy for you.
+                    <em>If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at gradthesis@psu.edu so that we may proxy for you.</em>
 
-                    If you have any further questions please contact gradthesis@psu.edu.
-                    Sincerely,
-                    The Graduate School
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         special_committee_review_request:
           message: |
                     Hello %{committee_member_name},
 
-                    The Graduate School of The Pennsylvania State University and %{full_name} require you to review and
-                    digitally sign a proposed work for which you have been listed as a committee member.
-                    In order to proceed and provide input on their work, please follow this link:
-                    %{review_url}
-                    or you can copy and paste this into your browser.
-                    %{seven_day_note}
-                    If you have any further questions please contact gradthesis@psu.edu.
-                    Sincerely,
-                    The Graduate School of The Pennsylvania State University
+                    The Graduate School of The Pennsylvania State University and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. To proceed and provide input on their work, please follow this link:  %{review_url} or you can copy and paste this into your browser. %{seven_day_note}
 
-                    You may also call (814)865-5448, or send mail to:
+                    <em>If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-1795 or email us at gradthesis@psu.edu so that we may proxy for you.</em>
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         committee_member_review_reminder:
           message: |
-                    Reminder: %{full_name} has submitted their %{degree_type} entitled %{title} for final review.
-                    Please visit this URL to conduct your final review:
-                    %{review_url}
-                    If you are serving on this committee in multiple roles, you will only need to submit your review once.
+                    Reminder: %{full_name} has submitted their %{degree_type} entitled %{title} for final review. Please visit this URL to conduct your final review: %{review_url}. If you are serving on this committee as both the program head or the professor in charge/director of graduate studies, you might be requested to approve the work twice. 
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    <em>If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-1795 or email us at gradthesis@psu.edu so that we may proxy for you.</em>
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         nonvoting_approval_reminder:
           message: |
                     Dear %{committee_member_name},              
                     This will be your final opportunity to vote on %{full_name}'s final work. If you do not vote 
-                    within seven days, your name will be removed from the student’s work.
+                    within seven days, your name will be removed from the student's work.
 
                     %{review_url}
         
@@ -206,152 +172,104 @@ en:
         seventh_day_to_chairs:
           message: |
                     The committee for %{author_name}'s %{degree_type} has not completed its review after 7 days.
-                    The committee members that must vote but have not are:
-
+                    The committee members who must vote but have not are:
                     %{committee_list}
-
                     Please secure the necessary votes within the next 5 business days.
-                    Sincerely,
-                    The Graduate School of The Pennsylvania State University
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         seventh_day_to_author:
           message: |
-                    Your %{degree_type} is being looked into by your committee's%{committee_chair} program head/chair %{program_head}
-                    to secure the necessary votes for completion.  This matter should be fixed in the next 5 business days.
-                    No action is required of you at this time.
-                    Sincerely,
-                    The Graduate School of The Pennsylvania State University
+                    Your %{degree_type} is being looked into by your committee's%{committee_chair} program head/chair %{program_head} to secure the necessary votes for completion. <em>Students are required to ensure that each of their committee members approves.</em> Please secure the necessary votes. You will be notified once your committee has reviewed and made a decision regarding your document.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         advisor_rejected:
           message: |
                     Your %{degree_type} has been rejected by your advisor.
-                    Please consult with your %{degree_type} advisor about revising your submission.  When you have completed
-                    your revisions, please resubmit your %{degree_type} for committee review.
+                    Please consult with your %{degree_type} advisor about revising your submission. When you have completed your revisions, please resubmit your %{degree_type} to the ETD for committee review.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         advisor_funding_discrepancy:
           message: |
-                    Your advisor has indicated that federal funds were%{funding_wording} used for your %{degree_type}.
-                    You have indicated otherwise. Please consult with your %{degree_type} advisor about this discrepancy.
-                    When you have completed your revisions, please resubmit your %{degree_type} for committee review.
+                    Your advisor has indicated that federal funds were%{funding_wording} used for your %{degree_type}. You have indicated otherwise. Please consult with your %{degree_type} advisor about this discrepancy.
+                    When you have completed your revisions, please resubmit your %{degree_type} to the ETD for committee review. 
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         committee_rejected_admin:
           message: |
-                    The committee for %{author_name}'s %{degree_type} has rejected their submission.
-                    The submission will automatically be available for the student to edit and resubmit for committee approval.
-
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
-                    Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
+                    The committee for %{author_name}'s %{degree_type} has rejected their submission. The submission is now available for the student to edit and resubmit for committee approval.
         committee_rejected_author:
           message: |
                     The committee reviewing your %{degree_type} has rejected your submission.
-                    You will need to make the necessary revisions or corrections to your document and resubmit your %{degree_type} for your committee to review.
+                    You will need to make the necessary revisions or corrections to your document and <a href="%{etd_site}" target="_blank">resubmit your %{degree_type} for your committee to review.</a>
                     This was the result of your committee's review:
-
                     %{review_results}
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         committee_rejected_committee:
           message: |
                     %{author_name}'s %{degree_type} titled "%{title}" has been rejected by its committee.
-                    The student has been asked to resubmit their work.  Once they have done this, you will be notified via email to review.
+                    The student has been asked to resubmit their work. Once they have done this, you will be notified via email to review.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         pending_returned_author:
           message: |
                     Your %{degree_type} has been rejected by request of an administrator.
-                    You will need to make the necessary revisions or corrections to your document and resubmit your %{degree_type} for your committee to review again.
+                    You will need to make the necessary revisions or corrections to your document and <a href="%{etd_site}" target="_blank">resubmit your %{degree_type} for your committee to review again.</a>
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         pending_returned_committee:
           message: |
                     %{author_name}'s eTD submission titled "%{title}" has been rejected at the request of an administrator.
-                    The student has been asked to resubmit their work.  Once they have done this, you will be notified via email to review.
+                    The student has been asked to resubmit their work. Once they have done this, you will be notified via email to review.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         committee_approved:
           message: |
-                    Your eTD has been reviewed by your committee and it is approved.
-                    No further action is needed by you at this time.  The Graduate School will now review your submission.
-                    You will be notified by email of your eTD approval or if changes are required within 2-3 weeks. 
+                    Your ETD has been reviewed and approved by your committee. The Graduate School will now review your submission. <b>Until you receive notification that the Graduate School has approved your submission, your work is not officially approved.</b> You will be notified by email of your ETD approval or if changes are required within 2-3 weeks.
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
-                    cc:%{committee_email_list}
         release_for_publication:
           message: |
-                    Your %{degree_type} titled "%{title}" has been released with the access level of Open Access.
-                    You can view your published submission at: %{url}.
+                    Your %{degree_type} titled "%{title}" has been released with the access level of Open Access. You can view your published submission at: %{url}.
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
+
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         release_for_publication_metadata_only:
           message: |
-                    The metadata for your %{degree_type} titled "%{title}" has been released.
-                    You can view this information at: %{url}.
-                    It retains its access level of %{access_level}.  The full publication will be released in two years.
+                    The metadata for your %{degree_type} titled "%{title}" has been released. You can view this information at: %{url}.
+                    Your work retains its access level of %{access_level}. <em>The full publication will be released in two years.</em>
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
 
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
                     Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
         access_level_updated:
           message: |
                     The Graduate School has changed the availability of the following eTD as shown below:
@@ -361,12 +279,10 @@ en:
                      New Availability - %{new_access_level}
                      Old Availability - %{old_access_level}
                      Graduation Year - %{graduation_year}
-                     If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                     You may also call (814)865-5448, or send mail to:
-                     Office of Theses and Dissertations
-                     115 Kern Building
-                     Graduate School
-                     University Park, PA  16802
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
+                    Best,
+
+                    Office of Theses and Dissertations
     program:
       label: Graduate Program
     committee:

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -72,6 +72,38 @@ en:
                     115 Kern Building
                     Graduate School
                     University Park, PA  16802
+        final_submission_received:
+          message: |
+                    Thank you for submitting your final %{degree_type}.  It will now be automatically sent to your committee for review and approval.
+                    No action is required of you at this time.
+                    You will be notified once your committee has reviewed and made a decision regarding your document.
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
+                    You may also call (814)865-5448, or send mail to:
+                    Office of Theses and Dissertations
+                    115 Kern Building
+                    Graduate School
+                    University Park, PA  16802
+        format_review_rejected:
+          message: |
+                    To be determined.
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
+                    You may also call (814)865-5448, or send mail to:
+                    Office of Theses and Dissertations
+                    115 Kern Building
+                    Graduate School
+                    University Park, PA  16802
+        format_review_accepted:
+          message: |
+                    To be determined.
+
+                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
+                    You may also call (814)865-5448, or send mail to:
+                    Office of Theses and Dissertations
+                    115 Kern Building
+                    Graduate School
+                    University Park, PA  16802       
         format_review_received:
           message: |
                     Thank you for submitting your %{degree_type} for format review. Our staff will be in touch with
@@ -89,18 +121,6 @@ en:
                     approved by The Office of Theses and Dissertations.
 
                     Please refer to the deadline calendar on the graduate school website under “Thesis and Dissertation Information”, for all deadlines.
-
-                    If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
-                    You may also call (814)865-5448, or send mail to:
-                    Office of Theses and Dissertations
-                    115 Kern Building
-                    Graduate School
-                    University Park, PA  16802
-        final_submission_received:
-          message: |
-                    Thank you for submitting your final %{degree_type}.  It will now be automatically sent to your committee for review and approval.
-                    No action is required of you at this time.
-                    You will be notified once your committee has reviewed and made a decision regarding your document.
 
                     If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu.
                     You may also call (814)865-5448, or send mail to:

--- a/config/locales/partners/en/honors/honors.en.yml
+++ b/config/locales/partners/en/honors/honors.en.yml
@@ -15,7 +15,8 @@ en:
     partner:
       abbrev: schreyer
       name: Schreyer Honors College
-      url: https://www.shc.psu.edu/academic/thesis/
+      etd_site: https://www.shc.psu.edu/academic/thesis/
+      explore_site: https://honors-explore.libraries.psu.edu
       slug: eHT
       description:
         title: Schreyer Honors College Theses
@@ -33,7 +34,7 @@ en:
         signature: 'Schreyer Honors College<br /> University Park, PA'
         final_submission_rejected:
           message: |
-                    "The final submission of your honors thesis has been rejected by the Schreyer Honors College. You will need to go back onto [the website](%{url}) to look at the feedback and resubmit with the necessary revisions.
+                    "The final submission of your honors thesis has been rejected by the Schreyer Honors College. You will need to go back onto <a href="%{etd_site}" target="_blank">the website</a> to look at the feedback and resubmit with the necessary revisions.
 
                     Sincerely,
                     Schreyer Honors College Academic Affairs
@@ -76,7 +77,7 @@ en:
                     SHCAcademics@psu.edu
         format_review_rejected:
           message: |
-                    Your thesis format review has been rejected. Please go back onto [the website](%{url}) to look at the feedback and resubmit with the necessary revisions.
+                    Your thesis format review has been rejected. Please go back onto <a href="%{etd_site}" target="_blank">the website</a> to look at the feedback and resubmit with the necessary revisions.
 
                     Sincerely,
                     Schreyer Honors College Academic Affairs
@@ -155,7 +156,7 @@ en:
                     SHCAcademics@psu.edu
         committee_rejected_author:
           message: |
-                    Your thesis has been rejected by a member of your committee. You will need to go back onto [the website](%{url}) to look at the feedback and resubmit with the necessary revisions.
+                    Your thesis has been rejected by a member of your committee. You will need to go back onto <a href="%{etd_site}" target="_blank">the website</a> to look at the feedback and resubmit with the necessary revisions.
 
                     Sincerely,
                     Schreyer Honors College Academic Affairs
@@ -177,7 +178,7 @@ en:
         pending_returned_author:
           message: |
                     Your %{degree_type} has been rejected by request of an administrator.
-                    You will need to go back onto [the website](%{url}) to look at the feedback and resubmit with the necessary revisions.
+                    You will need to go back onto <a href="%{etd_site}" target="_blank">the website</a> to look at the feedback and resubmit with the necessary revisions.
                     Sincerely,
                     Schreyer Honors College Academic Affairs
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,6 +301,7 @@ ActiveRecord::Schema.define(version: 2024_07_02_191344) do
     t.string "lionpath_semester"
     t.string "academic_program"
     t.string "degree_checkout_status"
+    t.datetime "author_release_warning_sent_at"
     t.datetime "acknowledgment_page_submitted_at"
     t.integer "candidate_number"
     t.index ["author_id"], name: "submissions_author_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,7 +301,6 @@ ActiveRecord::Schema.define(version: 2024_07_02_191344) do
     t.string "lionpath_semester"
     t.string "academic_program"
     t.string "degree_checkout_status"
-    t.datetime "author_release_warning_sent_at"
     t.datetime "acknowledgment_page_submitted_at"
     t.integer "candidate_number"
     t.index ["author_id"], name: "submissions_author_id_fk"

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe WorkflowMailer do
       end
     end
 
-    context "when the current partner does not send format_review emails" do
+    context "when the current partner does not send format_review emails", milsch: true do
       it "raises an InvalidPartner Error" do
         skip 'current partner SHOULD send format_review_accepted emails' unless current_partner.milsch?
 
@@ -105,8 +105,8 @@ RSpec.describe WorkflowMailer do
       end
     end
 
-    context "when the current partner should not send" do
-      it "raises an exception" do
+    context "when the current partner should not send", milsch: true do
+      it "raises an InvalidPartner Error" do
         skip 'current partner SHOULD send' unless current_partner.milsch?
         expect { email.deliver_now }.to raise_error WorkflowMailer::InvalidPartner
       end

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe WorkflowMailer do
     let(:email) { described_class.format_review_accepted(submission) }
     let(:partner_email) { current_partner.email_address }
 
-    context "when the current partner is 'sset'", sset: true do
+    context "when the current partner should receive format_review_accepted emails", sset: true, honors: true do
       before do
-        skip 'sset only' unless current_partner.sset?
+        skip 'current partner does not send format_review_accepted emails' unless current_partner.sset? || current_partner.honors? || current_partner.graduate?
       end
 
       it "sets an appropriate subject" do
@@ -73,36 +73,20 @@ RSpec.describe WorkflowMailer do
       end
 
       it "tells them that their format review has been accepted" do
-        expect(email.body).to match(/has been approved by administrators/i)
+        if current_partner.sset?
+          expect(email.body).to match(/has been approved by administrators/i)
+        elsif current_partner.honors?
+          expect(email.body).to match(/Your thesis format review has been approved!/i)
+        elsif current_partner.graduate?
+          expect(email.body).to match(/To be determined/i)
+        end
       end
     end
 
-    context "when the current partner is 'honors'", honors: true do
-      before do
-        skip 'honors only' unless current_partner.honors?
-      end
 
-      it "sets an appropriate subject" do
-        expect(email.subject).to match(/format review has been accepted/i)
-      end
-
-      it "is sent from the partner support email address" do
-        expect(email.from).to eq([partner_email])
-      end
-
-      it "is sent to the student's PSU email address" do
-        expect(author.psu_email_address).not_to be_blank
-        expect(email.to).to eq([author.psu_email_address])
-      end
-
-      it "tells them that their format review has been accepted" do
-        expect(email.body).to match(/Your thesis format review has been approved!/i)
-      end
-    end
-
-    context "when the current partner is neither 'sset' or 'honors'" do
-      it "raises an exception" do
-        skip 'not sset nor honors' if current_partner.sset? || current_partner.honors?
+    context "when the current partner does not send format_review emails" do
+      it "raises an InvalidPartner Error" do
+        skip 'partner DOES send format_review_accepted emails' unless current_partner.milsch?
 
         expect { email.deliver_now }.to raise_error WorkflowMailer::InvalidPartner
       end
@@ -113,9 +97,9 @@ RSpec.describe WorkflowMailer do
     let(:email) { described_class.format_review_rejected(submission) }
     let(:partner_email) { current_partner.email_address }
 
-    context "when the current partner is 'sset'", sset: true do
+    context "when the current partner should send ", sset: true, honors: true do
       before do
-        skip 'sset only' unless current_partner.sset?
+        skip 'current partner does NOT send format_review_rejected emails' unless current_partner.sset? || current_partner.honors?  || current_partner.graduate?
       end
 
       it "sets an appropriate subject" do
@@ -132,37 +116,20 @@ RSpec.describe WorkflowMailer do
       end
 
       it "tells them that their format review has been rejected" do
-        expect(email.body).to match(/Project Paper has been rejected/i)
+        if current_partner.sset?
+          expect(email.body).to match(/Project Paper has been rejected/i)
+        elsif current_partner.honors?
+          expect(email.body).to match(/Your thesis format review has been rejected/i)
+        elsif current_partner.graduate?
+          expect(email.body).to match(/To be determined/i)
+        end
       end
     end
 
-    context "when the current partner is 'honors'", honors: true do
-      before do
-        skip 'honors only' unless current_partner.honors?
-      end
 
-      it "sets an appropriate subject" do
-        expect(email.subject).to match(/format review has been rejected/i)
-      end
-
-      it "is sent from the partner support email address" do
-        expect(email.from).to eq([partner_email])
-      end
-
-      it "is sent to the student's PSU email address" do
-        expect(author.psu_email_address).not_to be_blank
-        expect(email.to).to eq([author.psu_email_address])
-      end
-
-      it "tells them that their format review has been rejected" do
-        expect(email.body).to match(/Your thesis format review has been rejected./i)
-      end
-    end
-
-    context "when the current partner is neither 'sset' nor 'honors'" do
+    context "when the current partner should not send" do
       it "raises an exception" do
-        skip 'not sset nor honors' if current_partner.sset? || current_partner.honors?
-
+        skip 'current partner SHOULD send' unless current_partner.milsch?
         expect { email.deliver_now }.to raise_error WorkflowMailer::InvalidPartner
       end
     end

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe WorkflowMailer do
 
     context "when the current partner does not send format_review emails" do
       it "raises an InvalidPartner Error" do
-        skip 'partner DOES send format_review_accepted emails' unless current_partner.milsch?
+        skip 'current partner SHOULD send format_review_accepted emails' unless current_partner.milsch?
 
         expect { email.deliver_now }.to raise_error WorkflowMailer::InvalidPartner
       end

--- a/spec/services/format_review_update_service_spec.rb
+++ b/spec/services/format_review_update_service_spec.rb
@@ -6,7 +6,7 @@ require 'shoulda-matchers'
 RSpec.describe FormatReviewUpdateService, type: :model do
   let(:committee_member) { FactoryBot.create :committee_member, created_at: DateTime.yesterday }
 
-  context 'it processes approved format review submissions' do
+  context 'it processes approved format review submissions', sset: true, honors: true, milsch: true do
     it 'approves a format review' do
       submission = FactoryBot.create :submission, :waiting_for_format_review_response, committee_members: [committee_member]
       params = ActionController::Parameters.new
@@ -27,12 +27,12 @@ RSpec.describe FormatReviewUpdateService, type: :model do
       expect(submission.committee_members.first.status).to eq('approved')
       expect(submission.committee_members.first.notes).to match(/\nThe admin user testuser123 changed Review Status to 'Approved' at: .*\n\nThe admin user testuser123 changed Voting Attribute to 'False' at:/)
       expect(submission.federal_funding).to eq false
-      expect(WorkflowMailer.deliveries.count).to eq 1 if current_partner.sset?
-      expect(WorkflowMailer.deliveries.count).to eq 0 unless current_partner.sset?
+      expect(WorkflowMailer.deliveries.count).to eq 1 unless current_partner.milsch?
+      expect(WorkflowMailer.deliveries.count).to eq 0 if current_partner.milsch?
     end
   end
 
-  context 'it processes rejected format review submissions' do
+  context 'it processes rejected format review submissions', sset: true, honors: true, milsch: true do
     it 'rejects a format review' do
       submission = FactoryBot.create :submission, :waiting_for_format_review_response, committee_members: [committee_member]
       params = ActionController::Parameters.new
@@ -49,8 +49,8 @@ RSpec.describe FormatReviewUpdateService, type: :model do
       expect(submission.semester).to eq(semester)
       expect(submission.committee_members.first.is_voting).to eq(false)
       expect(submission.committee_members.first.notes).to match(/\nThe admin user testuser123 changed Voting Attribute to 'False' at:/)
-      expect(WorkflowMailer.deliveries.count).to eq 1 if current_partner.sset?
-      expect(WorkflowMailer.deliveries.count).to eq 0 unless current_partner.sset?
+      expect(WorkflowMailer.deliveries.count).to eq 1 unless current_partner.milsch?
+      expect(WorkflowMailer.deliveries.count).to eq 0 if current_partner.milsch?
     end
   end
 


### PR DESCRIPTION
closes #796

Updates the text of the mailers, and changes the logic so that the grad school has format_approved and format_rejected emails. Also updates tests and correct some test holes that were there.