### PR TITLE
rename Intellectual Property Office to Office of Technology Management

### DIFF
--- a/app/models/invention_disclosure.rb
+++ b/app/models/invention_disclosure.rb
@@ -4,7 +4,7 @@ class InventionDisclosure < ApplicationRecord
   belongs_to :submission
 
   def self.description
-    'The Restricted option should be used exclusively for authors with patent issues.  Authors using this option are required to file an Invention Disclosure form with the Intellectual Property Office in order to obtain an Invention Disclosure Number.'.html_safe
+    'The Restricted option should be used exclusively for authors with patent issues.  Authors using this option are required to file an Invention Disclosure form with the Office of Technology Management in order to obtain an Invention Disclosure Number.'.html_safe
   end
 
   def self.prefix_range

--- a/spec/models/invention_disclosure_spec.rb
+++ b/spec/models/invention_disclosure_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe InventionDisclosure, type: :model do
 
     context 'it displays a message' do
       it 'has a description' do
-        expect(described_class.description).to eq('The Restricted option should be used exclusively for authors with patent issues.  Authors using this option are required to file an Invention Disclosure form with the Intellectual Property Office in order to obtain an Invention Disclosure Number.')
+        expect(described_class.description).to eq('The Restricted option should be used exclusively for authors with patent issues.  Authors using this option are required to file an Invention Disclosure form with the Office of Technology Management in order to obtain an Invention Disclosure Number.')
       end
 
       it 'has a prefix length' do


### PR DESCRIPTION
Fixes #806 