### PR TITLE
update grad school to new Fox naming

### DIFF
--- a/app/views/about/_graduate_about_text.html.erb
+++ b/app/views/about/_graduate_about_text.html.erb
@@ -1,9 +1,9 @@
-<h1>About the Graduate School eTD database.</h1>
+<h1>About the Fox Graduate School eTD database.</h1>
 <p>The primary purpose of a thesis or dissertation is to train the student in the process of scholarly research and writing under the direction of members of the Graduate Faculty. After the student has graduated and the work is published, it serves as a contribution to human knowledge, is useful to other scholars, and perhaps even to a more general audience.</p>
 <div class='h2'>Expand Creative Possibilities</div>
 <p>Electronic thesis and dissertations (eTDs) expand the creative possibilities open to students and empower students to convey a richer message by permitting video, sound, and color images to be integrated into their work. Submitting and archiving eTDs helps students to understand electronic publishing issues and provides greater access to students' research. Through the Web, people from any place on the globe can link directly to eTD collections at Penn State and other universities.
 <div class='h2'>Format Standards and Process</div>
-<p>The Graduate School, the University Libraries, and the Graduate Faculty of Penn State have established format standards that theses and dissertations must meet before receiving final approval as a part of the fulfillment of graduation requirements. The Office of Theses and Dissertations staff is responsible for verifying that all eTDs have met these requirements (more information may be found in the <a href='<%= I18n.t("#{current_partner.id}.partner.thesis_guide") %>'>Thesis and Dissertation Guide</a>).</p>
+<p>The Fox Graduate School, the University Libraries, and the Graduate Faculty of Penn State have established format standards that theses and dissertations must meet before receiving final approval as a part of the fulfillment of graduation requirements. The Office of Theses and Dissertations staff is responsible for verifying that all eTDs have met these requirements (more information may be found in the <a href='<%= I18n.t("#{current_partner.id}.partner.thesis_guide") %>'>Thesis and Dissertation Guide</a>).</p>
 <div class='h2'>Important Things</div>
 <ul>
   <li>The text of the eTD should be proofread and free of grammatical errors and typos.</li>

--- a/app/views/author/submissions/index.html.erb
+++ b/app/views/author/submissions/index.html.erb
@@ -4,7 +4,7 @@
     <br>
     <p class="thesis_info">Upload your thesis/dissertation to the eTD website for format review, including your front matter, back matter and at least 3 chapters. The Office of Theses and Dissertations will check the format review and email you a PDF with comments. When all corrections are made submit the final by the final submission deadline, no changes can be made after the final is submitted.  </p>
     <% if current_partner.graduate? %>
-      <p class="thesis_info">There is a <strong>one-time</strong> fee for each thesis and/or dissertation submission required prior to the final submission of the thesis or dissertation.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>.  You will not be permitted to submit your final document unless the fee is paid.</p>
+      <p class="thesis_info">There is a <strong>one-time</strong> fee for each thesis and/or dissertation submission required prior to the final submission of the thesis or dissertation.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Fox Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>.  You will not be permitted to submit your final document unless the fee is paid.</p>
     <% end %>
   </div>
 </div>

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -4,12 +4,12 @@ en:
       formats:
         medium: '%b %-d, %Y %l:%M %P'
     header:
-      title: Electronic Theses and Dissertations for Graduate School
+      title: Electronic Theses and Dissertations for J. Jeffrey and Ann Marie Fox Graduate School at Penn State
       image: ETD-Grad.png
     submission:
       create:
-        success: Your Graduate School submission was created successfully.
-        failure: There was a problem submitting your Graduate School eTD.
+        success: Your Fox Graduate School submission was created successfully.
+        failure: There was a problem submitting your Fox Graduate School eTD.
       new: If you would like to start a new thesis or dissertation, you may do so by clicking the following link.
       descriptor: 'thesis or dissertation'
       acknowledge:
@@ -25,12 +25,12 @@ en:
         initial: 'Initial here'
     partner:
       abbrev: graduate
-      name: Graduate School
+      name: Fox Graduate School
       url: 'https://gradschool.psu.edu/academics/theses-and-dissertations#Handbook-138642'
       slug: eTD
       description:
-        title: Graduate School Theses and Dissertations
-        text: <p>The primary purpose of a thesis or dissertation is to train the student in the process of scholarly research and writing under the direction of members of the Graduate Faculty. After the student has graduated and the work is published, it serves as a contribution to human knowledge, is useful to other scholars and perhaps even to a more general audience. Electronic thesis and dissertations (eTDs) expand the creative possibilities open to students and empower students to convey a richer message by permitting video, sound, and color images to be integrated into their work. Submitting and archiving eTDs helps students to understand electronic publishing issues and provides greater acess to students' research. Through the Web, people from any place on the globe can link directly to eTD collections at Penn State and other universities.</p><p>The Graduate School, the University Libraries, and the Graduate Faculty of Penn State have established format standards that theses and dissertations must meet before receiving final approval as fulfillment of graduate requirements.  The Office of Theses and Dissertations staff is responsible for verifying that all eTDs have met these requirements <a href="%{thesis_guide_link}">(refer to the Thesis and Dissertation Guide)</a>.  The text of the eTD should be proofread and free of grammatical errors and typos.  It is extremely important that the author carefully review and proofread the thesis or dissertation before submitting the final document.  After the official approval of the final eTD by the Office of Theses and Dissertations, changes will not be permitted.</p>
+        title: Fox Graduate School Theses and Dissertations
+        text: <p>The primary purpose of a thesis or dissertation is to train the student in the process of scholarly research and writing under the direction of members of the Graduate Faculty. After the student has graduated and the work is published, it serves as a contribution to human knowledge, is useful to other scholars and perhaps even to a more general audience. Electronic thesis and dissertations (eTDs) expand the creative possibilities open to students and empower students to convey a richer message by permitting video, sound, and color images to be integrated into their work. Submitting and archiving eTDs helps students to understand electronic publishing issues and provides greater acess to students' research. Through the Web, people from any place on the globe can link directly to eTD collections at Penn State and other universities.</p><p>The Fox Graduate School, the University Libraries, and the Graduate Faculty of Penn State have established format standards that theses and dissertations must meet before receiving final approval as fulfillment of graduate requirements.  The Office of Theses and Dissertations staff is responsible for verifying that all eTDs have met these requirements <a href="%{thesis_guide_link}">(refer to the Thesis and Dissertation Guide)</a>.  The text of the eTD should be proofread and free of grammatical errors and typos.  It is extremely important that the author carefully review and proofread the thesis or dissertation before submitting the final document.  After the official approval of the final eTD by the Office of Theses and Dissertations, changes will not be permitted.</p>
       alternate_email_hint: 'The Alternate email address will be used after your psu.edu email address expires.'
       semester_hint: Only upload your dissertation or thesis if you intend to graduate this semester or the following semester.
       thesis_guide: 'http://www.gradschool.psu.edu/index.cfm/current-students/etd/'
@@ -46,7 +46,7 @@ en:
         url: 'https://etda-explore.libraries.psu.edu'
         address: gradthesis@psu.edu
         list: 'ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com'
-        signature: 'Graduate School <br />Keller Building<br /> University Park, PA'
+        signature: 'Fox Graduate School <br />Keller Building<br /> University Park, PA'
         final_submission_rejected:
           message: |
                     Your final submission has been rejected by the Office of Theses and Dissertations. To see the necessary revisions, please review the notes on the <a href="%{etd_site}" target="_blank">ETD</a>. <em>The next step is to make the necessary revisions or corrections to your document and then, resubmit an updated final submission to the ETD.</em>
@@ -62,7 +62,7 @@ en:
           message: |
                     Congratulations! Your final submission has been approved by the Office of Theses and Dissertations. After graduation, your work will be available through Penn State's <a href="%{explore_site}" target="_blank">ETD database</a> and will be sent to ProQuest/UMI Dissertation Services for processing <em>unless you have chosen to restrict access to it.</em>
 
-                    If you have chosen “Penn State Restricted” or “Full Restricted” embargo statuses, it will automatically change to “Open Access” after two years. The access level for your %{degree_type} is: %{access_level}. Please accept our congratulations as you complete your degree. Commencement information can be found on the <a href="%{commencement_url}" target="_blank">Graduate School Commencement Page.</a>
+                    If you have chosen “Penn State Restricted” or “Full Restricted” embargo statuses, it will automatically change to “Open Access” after two years. The access level for your %{degree_type} is: %{access_level}. Please accept our congratulations as you complete your degree. Commencement information can be found on the <a href="%{commencement_url}" target="_blank">Fox Graduate School Commencement Page.</a>
 
                     If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
 
@@ -106,7 +106,7 @@ en:
                     Office of Theses and Dissertations    
         format_review_received:
           message: |
-                    Thank you for submitting your %{degree_type} format review. Our staff will be in touch with you when the review has been completed. If you are graduating this semester, you will receive the results of the review by email within 2-3 weeks. If you have not already done so, you must pay your thesis fee at the <a href="%{payment_portal_url}" target="_blank">Graduate School Payment Portal.</a> You only need to pay once. 
+                    Thank you for submitting your %{degree_type} format review. Our staff will be in touch with you when the review has been completed. If you are graduating this semester, you will receive the results of the review by email within 2-3 weeks. If you have not already done so, you must pay your thesis fee at the <a href="%{payment_portal_url}" target="_blank">Fox Graduate School Payment Portal.</a> You only need to pay once. 
 
                     If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call (814)865-1795.
 
@@ -126,7 +126,7 @@ en:
           message: |
                     Hello %{committee_member_name},
 
-                    The Graduate School and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. Please login to %{review_url} and complete this request. If you are serving on this committee as either the program head or the professor in charge/director of graduate studies, you might be requested to approve the work twice. 
+                    The Fox Graduate School and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. Please login to %{review_url} and complete this request. If you are serving on this committee as either the program head or the professor in charge/director of graduate studies, you might be requested to approve the work twice. 
 
                     <em>If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-5448 or email us at gradthesis@psu.edu so that we may proxy for you.</em>
 
@@ -139,7 +139,7 @@ en:
           message: |
                     Hello %{committee_member_name},
 
-                    The Graduate School of The Pennsylvania State University and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. To proceed and provide input on their work, please follow this link:  %{review_url} or you can copy and paste this into your browser. %{seven_day_note}
+                    The Fox Graduate School of The Pennsylvania State University and %{full_name} require you to review and digitally sign a proposed work for which you have been listed as a committee member. To proceed and provide input on their work, please follow this link:  %{review_url} or you can copy and paste this into your browser. %{seven_day_note}
 
                     <em>If you know you need to approve a student's work, but do not see it in your queue or the link is broken, your ability to vote has expired. To resolve this issue, please try clearing your cache and then trying the link again or try the link on a different browser. If that doesn't work, please call OTD at 814-865-1795 or email us at gradthesis@psu.edu so that we may proxy for you.</em>
 
@@ -249,7 +249,7 @@ en:
                     Office of Theses and Dissertations
         committee_approved:
           message: |
-                    Your ETD has been reviewed and approved by your committee. The Graduate School will now review your submission. <b>Until you receive notification that the Graduate School has approved your submission, your work is not officially approved.</b> You will be notified by email of your ETD approval or if changes are required within 2-3 weeks.
+                    Your ETD has been reviewed and approved by your committee. The Fox Graduate School will now review your submission. <b>Until you receive notification that the Fox Graduate School has approved your submission, your work is not officially approved.</b> You will be notified by email of your ETD approval or if changes are required within 2-3 weeks.
                     If you have questions or comments, please email the Office of Theses and Dissertations at gradthesis@psu.edu or call us at (814) 865-1795.
                     Best,
 
@@ -272,7 +272,7 @@ en:
                     Office of Theses and Dissertations
         access_level_updated:
           message: |
-                    The Graduate School has changed the availability of the following eTD as shown below:
+                    The Fox Graduate School has changed the availability of the following eTD as shown below:
                      Author - %{full_name}
                      Title - %{title}
                      Paper - %{degree_type}
@@ -335,7 +335,7 @@ en:
         description: '%{submission} rejected by committee'
       final_submission_submitted:
         title: Final Submission is Submitted
-        description: '%{submission} waiting to be reviewed for final formatting approval by the Graduate School'
+        description: '%{submission} waiting to be reviewed for final formatting approval by the Fox Graduate School'
       final_submission_incomplete:
         title: Final Submission is Incomplete
         description: Submissions that were rejected and need formatting corrections
@@ -344,7 +344,7 @@ en:
         description: Submitted and waiting to be approved
       final_submission_approved:
         title: Final Submission to be Released
-        description: Approved by committee and the Graduate School; waiting to be released
+        description: Approved by committee and the Fox Graduate School; waiting to be released
       final_submission_on_hold:
         title: Final Submission is On Hold
         description: Submissions that have been approved but are now being held from release
@@ -381,9 +381,9 @@ en:
       "Your final submission requires further revisions. To see these revisions, open the PDF below in Adobe Acrobat. Please note this DOES NOT require you to get committee approvals again. Rather, make the requested revisions and then upload the corrected file to the ETDA. The Office of Theses and Dissertations will review your submission again until it is error-free. Please resubmit by the deadline for your intended graduation semester requirements. Not doing so puts you at risk of being removed from the graduation list. \n \n Thank you and do reach out if you have any questions!"
     fee_message:
       master_thesis:
-        message: "Before proceeding to your final submission, you must pay the $10 thesis fee.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>."
+        message: "Before proceeding to your final submission, you must pay the $10 thesis fee.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Fox Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>."
       dissertation:
-        message: "Before proceeding to your final submission, you must pay the $50 dissertation fee.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>."
+        message: "Before proceeding to your final submission, you must pay the $50 dissertation fee.  The fee can be paid at the <a href='https://secure.gradsch.psu.edu/paymentportal/' target='_blank'>Payment Section</a> of the Fox Graduate School Thesis and Dissertation Information <a href='https://gradschool.psu.edu/completing-your-degree/thesis-and-dissertation-information/' target='_blank'>webpage</a>."
     admin:
       umg: 'cn=umg/psu.sas.etda-graduate-admins,dc=psu,dc=edu'
       submission:

--- a/config/locales/partners/en/graduate/graduate.en.yml
+++ b/config/locales/partners/en/graduate/graduate.en.yml
@@ -7,9 +7,6 @@ en:
       title: Electronic Theses and Dissertations for J. Jeffrey and Ann Marie Fox Graduate School at Penn State
       image: ETD-Grad.png
     submission:
-      create:
-        success: Your Fox Graduate School submission was created successfully.
-        failure: There was a problem submitting your Fox Graduate School eTD.
       new: If you would like to start a new thesis or dissertation, you may do so by clicking the following link.
       descriptor: 'thesis or dissertation'
       acknowledge:

--- a/config/locales/partners/en/honors/honors.en.yml
+++ b/config/locales/partners/en/honors/honors.en.yml
@@ -7,9 +7,6 @@ en:
       title: Electronic Theses for Schreyer Honors College
       image: ETD-Honors.png
     submission:
-      create:
-        success: Your Graduate School submission was created successfully.
-        failure: There was a problem submitting your Schreyer Honors Thesis (eHT).
       new: If you would like to start a new thesis submission, you may do so by clicking the following link.  Your final submission will not be complete until you have added your committee members.
       descriptor: 'thesis'
     partner:

--- a/config/locales/partners/en/milsch/milsch.en.yml
+++ b/config/locales/partners/en/milsch/milsch.en.yml
@@ -7,9 +7,6 @@ en:
       title: Electronic Theses for Millennium Scholars Program
       image: ETD-Milsch.png
     submission:
-      create:
-        success: Your Millennium Scholars Program submission was created successfully.
-        failure: There was a problem submitting your Millennium Scholars Thesis.
       new: If you would like to start a new thesis submission, you may do so by clicking the following link.
       descriptor: 'thesis'
     partner:

--- a/config/locales/partners/en/sset/sset.en.yml
+++ b/config/locales/partners/en/sset/sset.en.yml
@@ -7,9 +7,6 @@ en:
       title: Final Papers for the School of Science, Engineering, and Technology
       image: ETD-Sset.png
     submission:
-      create:
-        success: Your SSET submission was created successfully.
-        failure: There was a problem submitting your SSET Final Paper.
       new: If you would like to start a new final paper submission, you may do so by clicking the following link.
       descriptor: 'final paper'
     partner:

--- a/spec/mailers/workflow_mailer_spec.rb
+++ b/spec/mailers/workflow_mailer_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe WorkflowMailer do
         skip 'Graduate Only' unless current_partner.graduate?
 
         expect(email.body).to match(/\/special_committee\/#{commmittee_member_token.authentication_token}/)
-        expect(email.body).to match(/The Graduate School of The Pennsylvania State University/)
+        expect(email.body).to match(/The Fox Graduate School of The Pennsylvania State University/)
       end
 
       it "updates submission's approval_started_at if blank" do
@@ -678,7 +678,7 @@ RSpec.describe WorkflowMailer do
         skip 'Graduate Only' unless current_partner.graduate?
 
         expect(email.body).to match(/\/special_committee\/X/)
-        expect(email.body).to match(/The Graduate School of The Pennsylvania State University/)
+        expect(email.body).to match(/The Fox Graduate School of The Pennsylvania State University/)
       end
     end
   end


### PR DESCRIPTION
Fixes #811 

With the full name used in the header, all other instances can be just "the Fox Graduate School"