### PR TITLE
Autorelease revisions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -146,6 +146,7 @@ class Submission < ApplicationRecord
   scope :ok_to_release, -> { where('released_for_publication_at <= ?', Time.zone.today.end_of_day) }
   scope :ok_to_autorelease, -> {
                               ok_to_release.where(access_level: 'restricted_to_institution')
+                                           .where(status: 'released for publication metadata only')
                             }
   scope :release_warning_needed?, -> {
                                     where('released_metadata_at >= ?', Time.zone.today.years_ago(2).end_of_day)

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -16,9 +16,11 @@
 
 <div id="body-container" class="container-fluid">
   <main>
+    <div id="content-row" class="row d-flex justify-content-center">
+        <%= render partial: 'shared/flash_messages' unless flash.empty? %>
+    </div>
     <div id="content-container" class="container-fluid">
       <div id="content-row" class="row">
-        <%= render partial: 'shared/flash_messages' unless flash.empty? %>
 
         <%= yield %>
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -106,22 +106,32 @@ RSpec.describe Submission, type: :model do
     let!(:sub1) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.days_ago(1),
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub2) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today,
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub3) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.next_week,
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub4) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.days_ago(1),
-                        access_level: 'open_access'
+                        access_level: 'open_access',
+                        status: 'released for publication metadata only'
+    end
+    let!(:sub5) do
+      FactoryBot.create :submission,
+                        released_for_publication_at: Time.zone.today.days_ago(1),
+                        access_level: 'restricted_to_institution',
+                        status: 'waiting for publication release'
     end
 
     it 'returns submissions that are ready for autorelease' do

--- a/spec/services/auto_release_service_spec.rb
+++ b/spec/services/auto_release_service_spec.rb
@@ -8,22 +8,32 @@ RSpec.describe AutoReleaseService do
     let!(:sub1) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.days_ago(1),
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub2) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.next_week,
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub3) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.days_ago(1),
-                        access_level: 'restricted_to_institution'
+                        access_level: 'restricted_to_institution',
+                        status: 'released for publication metadata only'
     end
     let!(:sub4) do
       FactoryBot.create :submission,
                         released_for_publication_at: Time.zone.today.days_ago(1),
-                        access_level: 'restricted'
+                        access_level: 'restricted',
+                        status: 'released for publication metadata only'
+    end
+    let!(:sub5) do
+      FactoryBot.create :submission,
+                        released_for_publication_at: Time.zone.today.days_ago(1),
+                        access_level: 'restricted_to_institution',
+                        status: 'waiting for publication release'
     end
 
     before { allow(Submission).to receive(:release_for_publication).with([sub1.id, sub3.id], DateTime.now.end_of_day, 'Release as Open Access') }


### PR DESCRIPTION
makes two changes:

- centers extension flash message
- includes status = 'released for publication metadata only' in autorelease scope to ensure that submissions that have been withdrawn are not autoreleased