### PR TITLE
759 federal funding language

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -383,7 +383,7 @@ class Submission < ApplicationRecord
   end
 
   def federal_funding_details
-    super || build_federal_funding_details
+    super || (build_federal_funding_details if current_partner.graduate?)
   end
 
   # Initialize our committee members with empty records for each of the required roles.

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -79,7 +79,7 @@ class Submission < ApplicationRecord
             length: { maximum: 400 },
             presence: true, if: proc { |s| s.author_edit }
 
-  validates :federal_funding, inclusion: { in: [true, false] }, if: proc { |s| s.status_behavior.beyond_collecting_committee? && s.author_edit }
+  validates :federal_funding, inclusion: { in: [true, false] }, if: proc { |s| s.status_behavior.beyond_collecting_committee? && s.author_edit && !current_partner.graduate? }
 
   validates :abstract,
             :keywords,

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -80,6 +80,7 @@ class Submission < ApplicationRecord
             presence: true, if: proc { |s| s.author_edit }
 
   validates :federal_funding, inclusion: { in: [true, false] }, if: proc { |s| s.status_behavior.beyond_collecting_committee? && s.author_edit && !current_partner.graduate? }
+  validates_associated :federal_funding_details, message: 'Federal funding is invalid.', if: -> { current_partner.graduate? }
 
   validates :abstract,
             :keywords,

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
   describe "When collecting final submission files", honors: true, milsch: true do
     before do
       oidc_authorize_author
+      submission.federal_funding_details.update(training_support_funding: false, 
+                                                other_funding: false, 
+                                                training_support_acknowledged: false, 
+                                                other_funding_acknowledged: false)
     end
 
     let!(:author) { current_author }
@@ -11,7 +15,6 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
     let!(:committee_members) { create_committee(submission) }
     let!(:degree) { FactoryBot.create :degree, degree_type: DegreeType.default }
     let!(:approval_configuration) { FactoryBot.create :approval_configuration, degree_type: degree.degree_type, head_of_program_is_approving: false }
-    let!(:federal_funding_details) { FactoryBot.create :federal_funding_details, submission: }
 
     context "when I submit the 'Upload Final Submission Files' form" do
       it 'loads the page' do
@@ -60,6 +63,7 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
 
     context "when I submit the 'Upload Final Submission Files' form after committee rejection" do
       it 'proceeds to committee review stage and resets committee reviews' do
+        byebug
         submission.committee_members.first.update_attribute :status, 'rejected'
         submission.status = 'waiting for committee review rejected'
         submission.defended_at = Time.zone.yesterday

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
   describe "When collecting final submission files", honors: true, milsch: true do
     before do
       oidc_authorize_author
-      submission.federal_funding_details.update(training_support_funding: false, 
-                                                other_funding: false, 
-                                                training_support_acknowledged: false, 
+      submission.federal_funding_details.update(training_support_funding: false,
+                                                other_funding: false,
+                                                training_support_acknowledged: false,
                                                 other_funding_acknowledged: false)
     end
 

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
       submission.federal_funding_details.update(training_support_funding: false,
                                                 other_funding: false,
                                                 training_support_acknowledged: false,
-                                                other_funding_acknowledged: false)
+                                                other_funding_acknowledged: false) if current_partner.graduate?
     end
 
     let!(:author) { current_author }

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
 
     context "when I submit the 'Upload Final Submission Files' form after committee rejection" do
       it 'proceeds to committee review stage and resets committee reviews' do
-        byebug
         submission.committee_members.first.update_attribute :status, 'rejected'
         submission.status = 'waiting for committee review rejected'
         submission.defended_at = Time.zone.yesterday

--- a/spec/integration/author/submit_final_submission_spec.rb
+++ b/spec/integration/author/submit_final_submission_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe 'Submitting a final submission as an author', type: :integration,
   describe "When collecting final submission files", honors: true, milsch: true do
     before do
       oidc_authorize_author
-      submission.federal_funding_details.update(training_support_funding: false,
-                                                other_funding: false,
-                                                training_support_acknowledged: false,
-                                                other_funding_acknowledged: false) if current_partner.graduate?
+      if current_partner.graduate?
+        submission.federal_funding_details.update(training_support_funding: false,
+                                                  other_funding: false,
+                                                  training_support_acknowledged: false,
+                                                  other_funding_acknowledged: false)
+      end
     end
 
     let!(:author) { current_author }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -266,8 +266,9 @@ RSpec.describe Submission, type: :model do
       expect(submission).to be_valid
     end
 
-    it 'validates federal funding only when authors are editing beyond collecting committee' do
+    it 'validates federal funding only when authors are editing beyond collecting committee and not graduate', honors: true do
       skip 'non-graduate only' if current_partner.graduate?
+
       submission = FactoryBot.create :submission, :waiting_for_final_submission_response
       submission2 = FactoryBot.create :submission, :collecting_program_information
       submission.author_edit = true
@@ -1126,6 +1127,26 @@ RSpec.describe Submission, type: :model do
       [submission, submission2].each do |sub|
         expect(sub.update_federal_funding).to eq false
         expect(sub.federal_funding).to eq true
+      end
+    end
+  end
+
+  describe '#federal_funding_details' do
+    context 'when current_partner is graduate' do
+      it 'builds an empty federal_funding_details record' do
+        skip 'graduate only' if !current_partner.graduate?
+
+        submission = described_class.new
+        expect(submission.federal_funding_details.class).to eq FederalFundingDetails
+      end
+    end
+
+    context 'when current_partner is not graduate', honors: true do
+      it "doesn't build a federal_funding_details record" do
+        skip 'non-graduate only' if current_partner.graduate?
+
+        submission = described_class.new
+        expect(submission.federal_funding_details.class).to eq NilClass
       end
     end
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Submission, type: :model do
     end
 
     it 'validates federal_funding_details if current_partner graduate' do
-      skip 'graduate only' if current_partner.graduate?
+      skip 'graduate only' unless current_partner.graduate?
 
       submission = create :submission, :waiting_for_final_submission_response
       submission.build_federal_funding_details

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -266,23 +266,48 @@ RSpec.describe Submission, type: :model do
       expect(submission).to be_valid
     end
 
-    it 'validates federal funding only when authors are editing beyond collecting committee and not graduate', honors: true do
-      skip 'non-graduate only' if current_partner.graduate?
+    describe 'validating federal funding only when authors are editing beyond collecting committee', honors: true do
+      context 'when current_partner is not graduate' do
+        it 'validates depending on certain criteria' do
+          skip 'non-graduate only' if current_partner.graduate?
 
-      submission = FactoryBot.create :submission, :waiting_for_final_submission_response
-      submission2 = FactoryBot.create :submission, :collecting_program_information
-      submission.author_edit = true
-      submission.federal_funding = true
-      expect(submission).to be_valid
-      submission.federal_funding = false
-      expect(submission).to be_valid
-      submission.federal_funding = nil
-      expect(submission).not_to be_valid
-      submission2.federal_funding = nil
-      expect(submission2).to be_valid
-      submission.author_edit = false
-      submission.federal_funding = nil
-      expect(submission).to be_valid
+          submission = FactoryBot.create :submission, :waiting_for_final_submission_response
+          submission2 = FactoryBot.create :submission, :collecting_program_information
+          submission.author_edit = true
+          submission.federal_funding = true
+          expect(submission).to be_valid
+          submission.federal_funding = false
+          expect(submission).to be_valid
+          submission.federal_funding = nil
+          expect(submission).not_to be_valid
+          submission2.federal_funding = nil
+          expect(submission2).to be_valid
+          submission.author_edit = false
+          submission.federal_funding = nil
+          expect(submission).to be_valid
+        end
+      end
+
+      context 'when current_partner is graduate' do
+        it "does not validate so it's always valid" do
+          skip 'graduate only' if !current_partner.graduate?
+
+          submission = FactoryBot.create :submission, :waiting_for_final_submission_response
+          submission2 = FactoryBot.create :submission, :collecting_program_information
+          submission.author_edit = true
+          submission.federal_funding = true
+          expect(submission).to be_valid
+          submission.federal_funding = false
+          expect(submission).to be_valid
+          submission.federal_funding = nil
+          expect(submission).to be_valid
+          submission2.federal_funding = nil
+          expect(submission2).to be_valid
+          submission.author_edit = false
+          submission.federal_funding = nil
+          expect(submission).to be_valid
+        end
+      end
     end
 
     it 'validates publication release if author is submitting beyond format review' do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Submission, type: :model do
 
       context 'when current_partner is graduate' do
         it "does not validate so it's always valid" do
-          skip 'graduate only' if !current_partner.graduate?
+          skip 'graduate only' unless current_partner.graduate?
 
           submission = FactoryBot.create :submission, :waiting_for_final_submission_response
           submission2 = FactoryBot.create :submission, :collecting_program_information
@@ -308,6 +308,24 @@ RSpec.describe Submission, type: :model do
           expect(submission).to be_valid
         end
       end
+    end
+
+    it 'validates federal_funding_details if current_partner graduate' do
+      skip 'graduate only' if current_partner.graduate?
+
+      submission = create :submission, :waiting_for_final_submission_response
+      submission.build_federal_funding_details
+      submission.federal_funding_details.author_edit = true
+      expect(submission).not_to be_valid
+    end
+
+    it 'does not validate federal_funding_details if current_partner is not graduate', honors: true do
+      skip 'non-graduate only' if current_partner.graduate?
+
+      submission = create :submission, :waiting_for_final_submission_response
+      submission.build_federal_funding_details
+      submission.federal_funding_details.author_edit = true
+      expect(submission).to be_valid
     end
 
     it 'validates publication release if author is submitting beyond format review' do
@@ -1159,7 +1177,7 @@ RSpec.describe Submission, type: :model do
   describe '#federal_funding_details' do
     context 'when current_partner is graduate' do
       it 'builds an empty federal_funding_details record' do
-        skip 'graduate only' if !current_partner.graduate?
+        skip 'graduate only' unless current_partner.graduate?
 
         submission = described_class.new
         expect(submission.federal_funding_details.class).to eq FederalFundingDetails

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -267,6 +267,7 @@ RSpec.describe Submission, type: :model do
     end
 
     it 'validates federal funding only when authors are editing beyond collecting committee' do
+      skip 'non-graduate only' if current_partner.graduate?
       submission = FactoryBot.create :submission, :waiting_for_final_submission_response
       submission2 = FactoryBot.create :submission, :collecting_program_information
       submission.author_edit = true


### PR DESCRIPTION
I also added some logic in the `#federal_funding_details` method in `Submission` to only build federal_funding_details in the graduate instance.