### PR TITLE
866 alert banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The file `config/settings.local.yml` is not tracked in git.
 Currently this is used to add announcements quickly. By adding values such as:
 ```rb
 # Strings
-show_annoucement: true
+show_announcement: true
 announcement:
   header: "Announcement header text goes here"
   message: "Place your important message here"

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ The file `config/settings.local.yml` is not tracked in git.
 Currently this is used to add announcements quickly. By adding values such as:
 ```rb
 # Strings
-show_annoucements: true
+show_annoucement: true
 announcement:
+  header: "Announcement header text goes here"
   message: "Place your important message here"
 ```
 

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,6 +1,7 @@
 <div class="announcement container-fluid <%= Settings.announcement&.html_class %>">
     <div class="row align-items-center">
       <div class="col align-content-center alert-warning">
+        <h3 class="text-center"> <%= sanitize Settings.announcement&.header %></h3>
         <p class="text-center mt-2 mb-2 pb-1"><%= sanitize Settings.announcement&.message %></p>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="<%= page_classes %>">
-  <%= render partial: 'shared/announcements' if Settings.show_announcements %>
+  <%= render partial: 'shared/announcements' if Settings.show_announcement %>
   <div class="container-fluid">
     <div id="shield-and-logo" class="row">
       <div class="col-sm-1">

--- a/spec/integration/announcement_spec.rb
+++ b/spec/integration/announcement_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Announcement', :js do
-  context 'when show_announcements is false' do
+  context 'when show_announcement is false' do
     before do
       Settings.add_source!(
         {
-          show_announcements: false,
+          show_announcement: false,
           announcement: nil
         }
       )
@@ -24,7 +24,7 @@ RSpec.describe 'Announcement', :js do
     before do
       Settings.add_source!(
         {
-          show_announcements: nil,
+          show_announcement: nil,
           announcement: nil
         }
       )
@@ -41,7 +41,7 @@ RSpec.describe 'Announcement', :js do
     before do
       Settings.add_source!(
         {
-          show_announcements: true,
+          show_announcement: true,
           announcement: {
             message: 'ETDA is for cool kids'
           }


### PR DESCRIPTION
After talking to the Grad school, I realized that some announcements would have headers. This allows for an option header value to be passed in the settings.yml file.

Also changes "show_announcements" to "show_announcement" for consistency.