### PR TITLE
Upgrades net-sftp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'etda_utilities', '~> 0.0'
 # Ldap client
 gem 'net-ldap', '~> 0.16.1'
 # sftp for lionapth csv imports
-gem "net-sftp", "~> 3.0"
+gem "net-sftp", "~> 4.0"
 # Country drop-downs
 gem 'country_select', '~> 10.0.0'
 gem 'simple_form', "~> 5.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,11 +263,11 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-sftp (3.0.0)
-      net-ssh (>= 5.0.0, < 7.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (6.1.0)
+    net-ssh (7.3.0)
     niftany (0.11.0)
       colorize (~> 0.8.1)
       erb_lint (~> 0.0.22)
@@ -565,7 +565,7 @@ DEPENDENCIES
   net-imap
   net-ldap (~> 0.16.1)
   net-pop
-  net-sftp (~> 3.0)
+  net-sftp (~> 4.0)
   net-smtp
   niftany
   oauth2

--- a/app/models/lionpath/lionpath_csv_importer.rb
+++ b/app/models/lionpath/lionpath_csv_importer.rb
@@ -31,7 +31,7 @@ class Lionpath::LionpathCsvImporter
   end
 
   def sftp_download(pattern)
-    sftp = Net::SFTP.start(ENV['LIONPATH_SFTP_SERVER'], ENV['LIONPATH_SFTP_USER'], key_data: [ENV['LIONPATH_SSH_KEY']])
+    sftp = Net::SFTP.start(ENV['LIONPATH_SFTP_SERVER'], ENV['LIONPATH_SFTP_USER'], key_data: [ENV['LIONPATH_SSH_KEY']], non_interactive: true)
     file = sftp.dir
                .glob("out/", "#{pattern}*")
                .reject { |f| f.name.starts_with?('.') }

--- a/app/models/lionpath/lionpath_csv_importer.rb
+++ b/app/models/lionpath/lionpath_csv_importer.rb
@@ -31,6 +31,7 @@ class Lionpath::LionpathCsvImporter
   end
 
   def sftp_download(pattern)
+    sleep(20.minutes)
     sftp = Net::SFTP.start(ENV['LIONPATH_SFTP_SERVER'], ENV['LIONPATH_SFTP_USER'], key_data: [ENV['LIONPATH_SSH_KEY']], non_interactive: true)
     file = sftp.dir
                .glob("out/", "#{pattern}*")


### PR DESCRIPTION
Testing a fix in a preview branch.

We had been using the gem net-sftp 3, which used net-ssh 6. That had the code that was throwing the error.

net-sftp 4 uses net-ssh 7, which I'm hoping is combatible with OpenSSL. It no longer uses `generate_key!` but rather `generate` which should avoid the immutability error we were getting.