### PR TITLE
Bugfix ssh issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'etda_utilities', '~> 0.0'
 # Ldap client
 gem 'net-ldap', '~> 0.16.1'
 # sftp for lionapth csv imports
-gem "net-sftp", "~> 3.0"
+gem "net-sftp", "~> 4.0"
 # Country drop-downs
 gem 'country_select', '~> 10.0.0'
 gem 'simple_form', "~> 5.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,11 +263,11 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-sftp (3.0.0)
-      net-ssh (>= 5.0.0, < 7.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (6.1.0)
+    net-ssh (7.3.0)
     niftany (0.11.0)
       colorize (~> 0.8.1)
       erb_lint (~> 0.0.22)
@@ -565,7 +565,7 @@ DEPENDENCIES
   net-imap
   net-ldap (~> 0.16.1)
   net-pop
-  net-sftp (~> 3.0)
+  net-sftp (~> 4.0)
   net-smtp
   niftany
   oauth2

--- a/app/models/lionpath/lionpath_csv_importer.rb
+++ b/app/models/lionpath/lionpath_csv_importer.rb
@@ -31,7 +31,7 @@ class Lionpath::LionpathCsvImporter
   end
 
   def sftp_download(pattern)
-    sftp = Net::SFTP.start(ENV['LIONPATH_SFTP_SERVER'], ENV['LIONPATH_SFTP_USER'], key_data: [ENV['LIONPATH_SSH_KEY']])
+    sftp = Net::SFTP.start(ENV['LIONPATH_SFTP_SERVER'], ENV['LIONPATH_SFTP_USER'], key_data: [ENV['LIONPATH_SSH_KEY']], non_interactive: true)
     file = sftp.dir
                .glob("out/", "#{pattern}*")
                .reject { |f| f.name.starts_with?('.') }


### PR DESCRIPTION
There was an issue running the lionpath_import job that came down to SSH. We were using Net SFTP 3 and Net SSH 6.1.0, which used the method #generate_key! when creating a connection. #generate_key! which was throwing an error. Upgrading to net-sftp 4 (which in turns grabs net ssh 7) seems to avoid the error.

Also, setting the Net::Sftp.start argument of `non_interactive` to true keeps it from asking for a password if the key fails. Not a big deal either way, but having non_interactive true makes it a little easier to troubleshoot.