### PR TITLE
911 - Updates Candidate Number if different

### DIFF
--- a/app/models/lionpath/lionpath_program.rb
+++ b/app/models/lionpath/lionpath_program.rb
@@ -28,8 +28,19 @@ class Lionpath::LionpathProgram
     def submission_update(submission, row)
       if !submission.status_behavior.beyond_waiting_for_final_submission_response_rejected?
         submission.update submission_attrs(row)
-      elsif row['ChkoutStat'] != submission.degree_checkout_status
-        submission.update(degree_checkout_status: row['ChkoutStat'], lionpath_updated_at: DateTime.now)
+      else
+        if row['ChkoutStat'] != submission.degree_checkout_status
+          submission.update(
+            degree_checkout_status: row['ChkoutStat'],
+            lionpath_updated_at: DateTime.now
+          )
+        end
+        if row['Can Nbr'] != submission.candidate_number
+          submission.update(
+            candidate_number: row['Can Nbr'],
+            lionpath_updated_at: DateTime.now
+          )
+        end
       end
     end
 


### PR DESCRIPTION
closes #911 

Now Candidate Number will be updated upon lionpath program import, even if the submission is beyond waiting for final submission response.

This allows lionpath to update candidate numbers for accepted, embargoed, or published submissions.